### PR TITLE
GitHub Actions: Claude[bot]のPR検出条件を修正

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -15,7 +15,7 @@ jobs:
     if: |
       (
         github.event.pull_request.user.login == github.repository_owner ||
-        github.event.pull_request.user.login == 'claude'
+        github.event.pull_request.user.login == 'claude[bot]'
       ) &&
       github.event.pull_request.head.repo.full_name == github.repository
     


### PR DESCRIPTION
- claude-ai[bot]からclaude[bot]に修正
- 実際のGitHub PRユーザー名に基づいた正しい条件に更新