### PR TITLE
GitHub Actions: actions権限を読み取り専用に戻す

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -27,7 +27,7 @@ jobs:
       pull-requests: write
       issues: write
       id-token: write
-      actions: write # Required for Claude to read and write workflow files
+      actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -40,6 +40,9 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
+          # This is an optional setting that allows Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read
           
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
           # model: "claude-opus-4-20250514"


### PR DESCRIPTION
- actions: write から actions: read に切り戻し
- 削除したadditional_permissionsセクションを復元
- botアカウントによるワークフロー変更の制限により、書き込み権限が機能しないため