### PR TITLE
GitHub Actions: claude[bot]のレビュー権限を削除

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -13,10 +13,7 @@ on:
 jobs:
   claude-review:
     if: |
-      (
-        github.event.pull_request.user.login == github.repository_owner ||
-        github.event.pull_request.user.login == 'claude[bot]'
-      ) &&
+      github.event.pull_request.user.login == github.repository_owner &&
       github.event.pull_request.head.repo.full_name == github.repository
     
     runs-on: ubuntu-latest


### PR DESCRIPTION
- claude[bot]によるPRレビューが正常に動作しないため設定を削除
- リポジトリオーナーのPRのみレビューするように戻す