### PR TITLE
Vitestを明示的import方式に統一

### DIFF
--- a/__tests__/middleware.test.ts
+++ b/__tests__/middleware.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
 import { NextRequest } from "next/server";
+import { describe, expect, it } from "vitest";
 import { middleware } from "../middleware";
 
 describe("セキュリティミドルウェア", () => {

--- a/__tests__/middleware.test.ts
+++ b/__tests__/middleware.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from "vitest";
 import { NextRequest } from "next/server";
 import { middleware } from "../middleware";
 

--- a/pages/__tests__/index.test.tsx
+++ b/pages/__tests__/index.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen, waitFor, cleanup } from "@testing-library/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
-import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import Home from "../index";
 
 // Mock Next.js Head component

--- a/pages/__tests__/index.test.tsx
+++ b/pages/__tests__/index.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, cleanup } from "@testing-library/react";
 import type { ReactNode } from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
 import Home from "../index";
 
 // Mock Next.js Head component
@@ -14,6 +14,11 @@ describe("ホームページ", () => {
 	beforeEach(() => {
 		// Reset fetch mock before each test
 		vi.resetAllMocks();
+	});
+
+	afterEach(() => {
+		// Clean up DOM after each test
+		cleanup();
 	});
 
 	it("ページタイトルが表示される", () => {

--- a/pages/__tests__/index.test.tsx
+++ b/pages/__tests__/index.test.tsx
@@ -1,6 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import Home from "../index";
 
 // Mock Next.js Head component

--- a/pages/__tests__/index.test.tsx
+++ b/pages/__tests__/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import Home from "../index";

--- a/pages/api/__tests__/health.test.ts
+++ b/pages/api/__tests__/health.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from "vitest";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { createMocks } from "node-mocks-http";
 import handler from "../health";

--- a/pages/api/__tests__/health.test.ts
+++ b/pages/api/__tests__/health.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect } from "vitest";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { createMocks } from "node-mocks-http";
+import { describe, expect, it } from "vitest";
 import handler from "../health";
 
 describe("/api/health", () => {

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,4 +1,5 @@
-import "@testing-library/jest-dom";
+import { vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
 
 // Mock Next.js specific functions
 Object.defineProperty(window, "matchMedia", {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,7 +6,6 @@ export default defineConfig({
 		jsxImportSource: "react", // Specify React as JSX import source
 	},
 	test: {
-		globals: true,
 		environment: "jsdom", // Enable browser environment for React components
 		setupFiles: ["./tests/setup.ts"], // Setup file for React Testing Library
 		mockReset: true,


### PR DESCRIPTION
- vitest.config.tsからglobals設定を削除
- 全テストファイルで明示的import方式を使用

🤖 Generated with [Claude Code](https://claude.ai/code)