### PR TITLE
Server Actionsによるプロジェクト登録機能を実装

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
 			"version": "1.0.0",
 			"license": "ISC",
 			"dependencies": {
+				"@hookform/resolvers": "^5.2.1",
+				"@radix-ui/react-label": "^2.1.7",
+				"@radix-ui/react-slot": "^1.2.3",
 				"@types/pg": "^8.15.4",
 				"axios": "^1.10.0",
 				"class-variance-authority": "^0.7.1",
@@ -16,12 +19,14 @@
 				"dotenv": "^16.4.5",
 				"drizzle-kit": "^0.31.4",
 				"drizzle-orm": "^0.44.3",
+				"lucide-react": "^0.535.0",
 				"next": "^15.4.4",
 				"pg": "^8.16.3",
 				"react": "^19.1.0",
 				"react-dom": "^19.1.0",
+				"react-hook-form": "^7.61.1",
 				"tailwind-merge": "^3.3.1",
-				"zod": "^3.22.4"
+				"zod": "^3.25.76"
 			},
 			"devDependencies": {
 				"@anthropic-ai/claude-code": "^1.0.61",
@@ -1260,6 +1265,18 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/@hookform/resolvers": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.2.1.tgz",
+			"integrity": "sha512-u0+6X58gkjMcxur1wRWokA7XsiiBJ6aK17aPZxhkoYiK5J+HcTx0Vhu9ovXe6H+dVpO6cjrn2FkJTryXEMlryQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@standard-schema/utils": "^0.3.0"
+			},
+			"peerDependencies": {
+				"react-hook-form": "^7.55.0"
+			}
+		},
 		"node_modules/@img/sharp-darwin-arm64": {
 			"version": "0.33.5",
 			"resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
@@ -1929,6 +1946,85 @@
 				"node": ">=14"
 			}
 		},
+		"node_modules/@radix-ui/react-compose-refs": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+			"integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-label": {
+			"version": "2.1.7",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.7.tgz",
+			"integrity": "sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-primitive": "2.1.3"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-primitive": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+			"integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-slot": "1.2.3"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-slot": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+			"integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-compose-refs": "1.1.2"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@rollup/rollup-android-arm-eabi": {
 			"version": "4.45.0",
 			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.45.0.tgz",
@@ -2209,6 +2305,12 @@
 				"win32"
 			]
 		},
+		"node_modules/@standard-schema/utils": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+			"integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+			"license": "MIT"
+		},
 		"node_modules/@swc/helpers": {
 			"version": "0.5.15",
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -2405,7 +2507,7 @@
 			"version": "19.1.8",
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
 			"integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"csstype": "^3.0.2"
@@ -2415,7 +2517,7 @@
 			"version": "19.1.6",
 			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.6.tgz",
 			"integrity": "sha512-4hOiT/dwO8Ko0gV1m/TJZYk3y0KBnY9vzDh7W+DH17b2HFSOGgdj33dhihPeuy3l0q23+4e+hoXHV6hCC4dCXw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"peerDependencies": {
 				"@types/react": "^19.0.0"
@@ -3173,7 +3275,7 @@
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
 			"integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/data-urls": {
@@ -5240,6 +5342,15 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/lucide-react": {
+			"version": "0.535.0",
+			"resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.535.0.tgz",
+			"integrity": "sha512-2E3+YWGLpjZ8ejIYrdqxVjWMSMiRQHmU6xZYE9xA2SC5j2m0NeB4/acjhRdhxbfniBKoNEukDDQnmShTxwOQ4g==",
+			"license": "ISC",
+			"peerDependencies": {
+				"react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
 		"node_modules/lz-string": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
@@ -6163,6 +6274,22 @@
 			},
 			"peerDependencies": {
 				"react": "^19.1.0"
+			}
+		},
+		"node_modules/react-hook-form": {
+			"version": "7.61.1",
+			"resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.61.1.tgz",
+			"integrity": "sha512-2vbXUFDYgqEgM2RcXcAT2PwDW/80QARi+PKmHy5q2KhuKvOlG8iIYgf7eIlIANR5trW9fJbP4r5aub3a4egsew==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/react-hook-form"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17 || ^18 || ^19"
 			}
 		},
 		"node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,9 @@
 		"vitest": "^2.0.0"
 	},
 	"dependencies": {
+		"@hookform/resolvers": "^5.2.1",
+		"@radix-ui/react-label": "^2.1.7",
+		"@radix-ui/react-slot": "^1.2.3",
 		"@types/pg": "^8.15.4",
 		"axios": "^1.10.0",
 		"class-variance-authority": "^0.7.1",
@@ -58,12 +61,14 @@
 		"dotenv": "^16.4.5",
 		"drizzle-kit": "^0.31.4",
 		"drizzle-orm": "^0.44.3",
+		"lucide-react": "^0.535.0",
 		"next": "^15.4.4",
 		"pg": "^8.16.3",
 		"react": "^19.1.0",
 		"react-dom": "^19.1.0",
+		"react-hook-form": "^7.61.1",
 		"tailwind-merge": "^3.3.1",
-		"zod": "^3.22.4"
+		"zod": "^3.25.76"
 	},
 	"lint-staged": {
 		"*.{ts,tsx}": [

--- a/src/api/types/project.ts
+++ b/src/api/types/project.ts
@@ -10,4 +10,8 @@ export interface GitLabProject {
 	id: number;
 	description: string | null;
 	name: string;
+	web_url?: string;
+	default_branch?: string;
+	visibility?: "public" | "internal" | "private";
+	created_at?: string;
 }

--- a/src/app/projects/__tests__/actions.test.ts
+++ b/src/app/projects/__tests__/actions.test.ts
@@ -1,9 +1,29 @@
-import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
+import { redirect } from "next/navigation";
+import {
+	afterAll,
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from "vitest";
+import type { GitLabApiClient as GitLabApiClientType } from "@/api/gitlab-client";
+import { GitLabApiClient } from "@/api/gitlab-client";
 import { closeConnection } from "@/database/connection";
-import { ProjectsRepository } from "@/database/repositories/projects";
-import { createProject } from "@/database/testing/factories";
+import { createProject } from "@/database/testing/factories/index";
 import { withTransaction } from "@/database/testing/transaction";
-import { getProjects } from "../actions";
+import { getProjects, registerProject } from "../actions";
+
+// モック設定
+vi.mock("next/navigation", () => ({
+	redirect: vi.fn(),
+}));
+
+vi.mock("@/api/gitlab-client");
+
+const mockGitLabApiClient = vi.mocked(GitLabApiClient);
+const mockRedirect = vi.mocked(redirect);
 
 describe("getProjects Server Action", () => {
 	afterAll(async () => {
@@ -34,17 +54,147 @@ describe("getProjects Server Action", () => {
 	});
 
 	it("データベースエラー時に適切なエラーを投げる", async () => {
-		// spyOnを使用してfindAllメソッドをモック
-		const findAllSpy = vi
-			.spyOn(ProjectsRepository.prototype, "findAll")
+		// projectsRepositoryのfindAllメソッドを直接モック
+		const { projectsRepository } = await import("@/database/index");
+		const originalFindAll = projectsRepository.findAll;
+
+		// 一時的にエラーを投げるようにモック
+		projectsRepository.findAll = vi
+			.fn()
 			.mockRejectedValue(new Error("Database connection failed"));
 
-		// エラーが適切に投げられることを確認
-		await expect(getProjects()).rejects.toThrow(
-			"プロジェクト一覧の取得に失敗しました",
+		try {
+			// エラーが適切に投げられることを確認
+			await expect(getProjects()).rejects.toThrow(
+				"プロジェクト一覧の取得に失敗しました",
+			);
+		} finally {
+			// 元のメソッドに戻す
+			projectsRepository.findAll = originalFindAll;
+		}
+	});
+});
+
+describe("registerProject Server Action", () => {
+	afterAll(async () => {
+		await closeConnection();
+	});
+
+	const mockFormData = (url: string) => {
+		const formData = new FormData();
+		formData.append("url", url);
+		return formData;
+	};
+
+	const mockGitLabProject = {
+		id: 123,
+		name: "test-project",
+		description: "Test project description",
+		web_url: "https://gitlab.example.com/group/test-project",
+		default_branch: "main",
+		visibility: "private" as const,
+		created_at: "2023-01-01T00:00:00Z",
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+
+		// GitLab APIクライアントのモック
+		const mockClient: Partial<GitLabApiClientType> = {
+			getProject: vi.fn().mockResolvedValue(mockGitLabProject),
+		};
+		mockGitLabApiClient.mockReturnValue(mockClient as GitLabApiClientType);
+	});
+
+	it("should successfully register a new project", async () => {
+		await withTransaction(async () => {
+			const formData = mockFormData(
+				"https://gitlab.example.com/group/test-project",
+			);
+
+			// プロジェクト登録を実行
+			await registerProject(null, formData);
+
+			// redirectが呼ばれたことを確認
+			expect(mockRedirect).toHaveBeenCalledWith("/projects");
+
+			// データベースにプロジェクトが登録されたことを確認
+			const { projectsRepository } = await import("@/database/index");
+			const projects = await projectsRepository.findAll();
+
+			expect(projects).toHaveLength(1);
+			expect(projects[0]).toMatchObject({
+				gitlab_id: mockGitLabProject.id,
+				name: mockGitLabProject.name,
+				description: mockGitLabProject.description,
+				web_url: mockGitLabProject.web_url,
+				default_branch: mockGitLabProject.default_branch,
+				visibility: mockGitLabProject.visibility,
+			});
+		});
+	});
+
+	it("should return error for invalid URL", async () => {
+		const formData = mockFormData("invalid-url");
+
+		const result = await registerProject(null, formData);
+
+		expect(result.success).toBe(false);
+		expect(result.error).toContain("有効なURL");
+	});
+
+	it("should return error for empty URL", async () => {
+		const formData = mockFormData("");
+
+		const result = await registerProject(null, formData);
+
+		expect(result.success).toBe(false);
+		expect(result.error).toBe("URLは必須です");
+	});
+
+	it("should return error for non-GitLab URL", async () => {
+		const formData = mockFormData("https://github.com/user/repo");
+
+		const result = await registerProject(null, formData);
+
+		expect(result.success).toBe(false);
+		expect(result.error).toBe(
+			"GitLabプロジェクトの有効なURLを入力してください",
+		);
+	});
+
+	it("should return error when project already exists", async () => {
+		await withTransaction(async () => {
+			// 既存プロジェクトを作成
+			await createProject({
+				gitlab_id: mockGitLabProject.id,
+				name: mockGitLabProject.name,
+			});
+
+			const formData = mockFormData(
+				"https://gitlab.example.com/group/test-project",
+			);
+
+			const result = await registerProject(null, formData);
+
+			expect(result.success).toBe(false);
+			expect(result.error).toBe("このプロジェクトは既に登録されています");
+		});
+	});
+
+	it("should handle GitLab API errors", async () => {
+		const mockClient: Partial<GitLabApiClientType> = {
+			getProject: vi.fn().mockRejectedValue(new Error("GitLab API error")),
+		};
+		mockGitLabApiClient.mockReturnValue(mockClient as GitLabApiClientType);
+
+		const formData = mockFormData(
+			"https://gitlab.example.com/group/test-project",
 		);
 
-		// メソッドが呼び出されたことを確認
-		expect(findAllSpy).toHaveBeenCalledOnce();
+		const result = await registerProject(null, formData);
+
+		expect(result.success).toBe(false);
+		expect(result.error).toBe("GitLab API error");
 	});
 });

--- a/src/app/projects/actions.ts
+++ b/src/app/projects/actions.ts
@@ -1,19 +1,124 @@
 "use server";
 
-import { ProjectsRepository } from "@/database/repositories/projects";
+import { redirect } from "next/navigation";
+import { z } from "zod";
+import { GitLabApiClient } from "@/api/gitlab-client";
+import { projectsRepository } from "@/database/index";
 import type { Project } from "@/database/schema/projects";
+import { projectRegistrationSchema } from "@/lib/validation/project-schemas";
 
 /**
  * プロジェクト一覧を取得するServer Action
  * @returns プロジェクト配列
  */
 export async function getProjects(): Promise<Project[]> {
-	const projectsRepository = new ProjectsRepository();
-
 	try {
 		return await projectsRepository.findAll();
 	} catch (error) {
 		console.error("プロジェクト一覧の取得に失敗しました:", error);
 		throw new Error("プロジェクト一覧の取得に失敗しました");
+	}
+}
+
+/**
+ * プロジェクト登録のServer Action結果型
+ */
+export type ProjectRegistrationResult = {
+	success: boolean;
+	error?: string;
+	project?: {
+		id: number;
+		name: string;
+		gitlab_id: number;
+		web_url: string;
+	};
+};
+
+/**
+ * URLからプロジェクトスラッグを抽出
+ */
+function extractProjectSlug(url: string): string {
+	const urlObj = new URL(url);
+	const pathSegments = urlObj.pathname.split("/").filter(Boolean);
+
+	if (pathSegments.length < 2) {
+		throw new Error("有効なプロジェクトパスではありません");
+	}
+
+	// 最後の2つのセグメントをgroup/projectとして取得
+	return pathSegments.slice(-2).join("/");
+}
+
+/**
+ * プロジェクト登録Server Action
+ */
+export async function registerProject(
+	_prevState: ProjectRegistrationResult | null,
+	formData: FormData,
+): Promise<ProjectRegistrationResult> {
+	try {
+		// フォームデータの取得とバリデーション
+		const url = formData.get("url");
+		const validatedData = projectRegistrationSchema.parse({ url });
+		const projectSlug = extractProjectSlug(validatedData.url);
+
+		// GitLab APIクライアントの作成
+		const gitlabClient = new GitLabApiClient();
+
+		// GitLab APIからプロジェクト情報を取得
+		const gitlabProject = await gitlabClient.getProject(projectSlug);
+
+		// 既存プロジェクトのチェック
+		const existingProject = await projectsRepository.findByGitlabId(
+			gitlabProject.id,
+		);
+
+		if (existingProject) {
+			return {
+				success: false,
+				error: "このプロジェクトは既に登録されています",
+			};
+		}
+
+		// データベースにプロジェクトを作成
+		await projectsRepository.create({
+			gitlab_id: gitlabProject.id,
+			name: gitlabProject.name,
+			description: gitlabProject.description || null,
+			web_url: validatedData.url,
+			default_branch: gitlabProject.default_branch || "main",
+			visibility: (gitlabProject.visibility || "private") as
+				| "public"
+				| "internal"
+				| "private",
+			gitlab_created_at: new Date(gitlabProject.created_at || Date.now()),
+		});
+
+		// 成功時は一覧ページにリダイレクト
+		redirect("/projects");
+	} catch (error) {
+		console.error("プロジェクト登録エラー:", error);
+
+		// Zodバリデーションエラー
+		if (error instanceof z.ZodError) {
+			return {
+				success: false,
+				error: error.errors[0]?.message || "入力データが無効です",
+			};
+		}
+
+		// リダイレクトエラーは再スロー
+		if (error instanceof Error && error.message === "NEXT_REDIRECT") {
+			throw error;
+		}
+
+		// その他のエラー
+		return {
+			success: false,
+			error:
+				error instanceof Error
+					? error.message
+					: "プロジェクトの登録に失敗しました",
+		};
 	}
 }

--- a/src/app/projects/new/__tests__/page.test.tsx
+++ b/src/app/projects/new/__tests__/page.test.tsx
@@ -1,0 +1,54 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import NewProjectPage from "../page";
+
+// ProjectRegistrationFormコンポーネントをモック
+vi.mock("@/components/projects/project-registration-form", () => ({
+	ProjectRegistrationForm: () => (
+		<div data-testid="project-registration-form">
+			Mock ProjectRegistrationForm
+		</div>
+	),
+}));
+
+describe("NewProjectPage", () => {
+	afterEach(() => {
+		cleanup();
+	});
+
+	it("ユーザーがプロジェクト登録ページを正しく利用できる", () => {
+		render(<NewProjectPage />);
+
+		// ページの目的が明確に表示される
+		expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+			"プロジェクト登録",
+		);
+		expect(
+			screen.getByText("新しいGitLabプロジェクトをシステムに登録します"),
+		).toBeInTheDocument();
+
+		// ナビゲーションが機能する
+		const backLink = screen.getByRole("link", {
+			name: /プロジェクト一覧に戻る/,
+		});
+		expect(backLink).toHaveAttribute("href", "/projects");
+
+		// メイン機能が利用可能
+		expect(screen.getByTestId("project-registration-form")).toBeInTheDocument();
+
+		// アクセシビリティが確保されている
+		expect(screen.getByRole("navigation")).toBeInTheDocument();
+		expect(screen.getByRole("banner")).toBeInTheDocument();
+	});
+
+	it("ナビゲーションアイコンが表示される", () => {
+		render(<NewProjectPage />);
+
+		// 戻るリンクにアイコンが含まれている
+		const backLink = screen.getByRole("link", {
+			name: /プロジェクト一覧に戻る/,
+		});
+		const svg = backLink.querySelector("svg");
+		expect(svg).toBeInTheDocument();
+	});
+});

--- a/src/app/projects/new/page.tsx
+++ b/src/app/projects/new/page.tsx
@@ -1,0 +1,31 @@
+import { ChevronLeft } from "lucide-react";
+import Link from "next/link";
+import { ProjectRegistrationForm } from "@/components/projects/project-registration-form";
+
+export default function NewProjectPage() {
+	return (
+		<div className="container mx-auto py-8 px-4 max-w-4xl">
+			{/* パンくずリスト */}
+			<nav className="flex items-center space-x-2 text-sm text-muted-foreground mb-6">
+				<Link
+					href="/projects"
+					className="flex items-center hover:text-foreground transition-colors"
+				>
+					<ChevronLeft className="h-4 w-4" />
+					プロジェクト一覧に戻る
+				</Link>
+			</nav>
+
+			{/* ページヘッダー */}
+			<header className="mb-8">
+				<h1 className="text-3xl font-bold">プロジェクト登録</h1>
+				<p className="text-muted-foreground mt-2">
+					新しいGitLabプロジェクトをシステムに登録します
+				</p>
+			</header>
+
+			{/* 登録フォーム */}
+			<ProjectRegistrationForm />
+		</div>
+	);
+}

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,4 +1,7 @@
+import { Plus } from "lucide-react";
+import Link from "next/link";
 import { ProjectCard } from "@/components/projects/project-card";
+import { Button } from "@/components/ui/button";
 import { getProjects } from "./actions";
 
 export default async function ProjectsPage() {
@@ -7,10 +10,23 @@ export default async function ProjectsPage() {
 	return (
 		<div className="py-8 px-4 max-w-7xl mx-auto">
 			<header className="mb-8">
-				<h1 className="text-3xl font-bold mb-2">プロジェクト一覧</h1>
-				<p className="text-muted-foreground">
-					GitLabから取得したプロジェクトの一覧を表示しています
-				</p>
+				<div className="flex items-center justify-between">
+					<div>
+						<h1 className="text-3xl font-bold mb-2">プロジェクト一覧</h1>
+						<p className="text-muted-foreground">
+							GitLabから取得したプロジェクトの一覧を表示しています
+						</p>
+					</div>
+					<Button asChild>
+						<Link
+							href="/projects/new"
+							className="inline-flex items-center gap-2"
+						>
+							<Plus className="h-4 w-4" />
+							新規プロジェクト登録
+						</Link>
+					</Button>
+				</div>
 			</header>
 
 			{projects.length === 0 ? (

--- a/src/components/projects/__tests__/project-registration-form.test.tsx
+++ b/src/components/projects/__tests__/project-registration-form.test.tsx
@@ -1,0 +1,95 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useFormState } from "react-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ProjectRegistrationForm } from "../project-registration-form";
+
+// React DOMのuseFormStateをモック
+vi.mock("react-dom", () => ({
+	useFormState: vi.fn(),
+}));
+
+const mockUseFormState = vi.mocked(useFormState);
+
+describe("ProjectRegistrationForm Component", () => {
+	const mockFormAction = vi.fn();
+
+	beforeEach(() => {
+		// デフォルトのモック状態 (React 19のuseFormStateは3つの値を返す)
+		mockUseFormState.mockReturnValue([null, mockFormAction, false]);
+	});
+
+	afterEach(() => {
+		cleanup();
+		vi.clearAllMocks();
+	});
+
+	it("should render form with all required elements", () => {
+		render(<ProjectRegistrationForm />);
+
+		// タイトルとフィールド
+		expect(screen.getByText("新しいプロジェクトを登録")).toBeInTheDocument();
+		expect(
+			screen.getByLabelText("GitLab プロジェクト URL"),
+		).toBeInTheDocument();
+
+		// 説明文
+		expect(
+			screen.getByText(/登録したいGitLabプロジェクトのURLを入力してください。/),
+		).toBeInTheDocument();
+
+		// アクションボタン
+		expect(screen.getByText("プロジェクトを登録")).toBeInTheDocument();
+
+		// キャンセルリンク
+		const cancelLink = screen.getByText("キャンセル");
+		expect(cancelLink).toBeInTheDocument();
+		expect(cancelLink.closest("a")).toHaveAttribute("href", "/projects");
+	});
+
+	it("should accept user input in URL field", async () => {
+		const user = userEvent.setup();
+		render(<ProjectRegistrationForm />);
+
+		const urlInput = screen.getByLabelText("GitLab プロジェクト URL");
+		const testUrl = "https://gitlab.com/test/project";
+
+		await user.type(urlInput, testUrl);
+		expect(urlInput).toHaveValue(testUrl);
+	});
+
+	it("should display error message from server", () => {
+		const errorState = {
+			success: false,
+			error: "プロジェクトが見つかりません",
+		};
+
+		mockUseFormState.mockReturnValue([errorState, mockFormAction, false]);
+		render(<ProjectRegistrationForm />);
+
+		expect(
+			screen.getByText("プロジェクトが見つかりません"),
+		).toBeInTheDocument();
+	});
+
+	it("should display success message with project name", () => {
+		const successState = {
+			success: true,
+			project: {
+				id: 1,
+				name: "テストプロジェクト",
+				gitlab_id: 123,
+				web_url: "https://gitlab.com/test/project",
+			},
+		};
+
+		mockUseFormState.mockReturnValue([successState, mockFormAction, false]);
+		render(<ProjectRegistrationForm />);
+
+		expect(
+			screen.getByText(
+				"プロジェクト「テストプロジェクト」を正常に登録しました。",
+			),
+		).toBeInTheDocument();
+	});
+});

--- a/src/components/projects/project-registration-form.tsx
+++ b/src/components/projects/project-registration-form.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import Link from "next/link";
+import { useFormState } from "react-dom";
+import { useForm } from "react-hook-form";
+import { registerProject } from "@/app/projects/actions";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+	Form,
+	FormControl,
+	FormDescription,
+	FormField,
+	FormItem,
+	FormLabel,
+	FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import {
+	type ProjectRegistrationData,
+	projectRegistrationSchema,
+} from "@/lib/validation/project-schemas";
+
+type FormData = ProjectRegistrationData;
+
+/**
+ * プロジェクト登録フォームコンポーネント
+ */
+export function ProjectRegistrationForm() {
+	const [state, formAction] = useFormState(registerProject, null);
+
+	const form = useForm<FormData>({
+		resolver: zodResolver(projectRegistrationSchema),
+		defaultValues: {
+			url: "",
+		},
+	});
+
+	return (
+		<Card className="max-w-2xl">
+			<CardHeader>
+				<CardTitle>新しいプロジェクトを登録</CardTitle>
+			</CardHeader>
+			<CardContent>
+				<Form {...form}>
+					<form action={formAction} className="space-y-6">
+						{/* エラー表示 */}
+						{state && !state.success && (
+							<div className="p-4 text-sm text-destructive bg-destructive/10 border border-destructive/20 rounded-md">
+								{state.error}
+							</div>
+						)}
+
+						{/* 成功表示（リダイレクト前に表示される可能性） */}
+						{state?.success && state.project && (
+							<div className="p-4 text-sm text-green-700 bg-green-50 border border-green-200 rounded-md">
+								プロジェクト「{state.project.name}」を正常に登録しました。
+							</div>
+						)}
+
+						<FormField
+							control={form.control}
+							name="url"
+							render={({ field }) => (
+								<FormItem>
+									<FormLabel>GitLab プロジェクト URL</FormLabel>
+									<FormControl>
+										<Input
+											placeholder="https://gitlab.example.com/group/project"
+											{...field}
+											name="url"
+										/>
+									</FormControl>
+									<FormDescription>
+										登録したいGitLabプロジェクトのURLを入力してください。 例:
+										https://gitlab.com/group/project
+									</FormDescription>
+									<FormMessage />
+								</FormItem>
+							)}
+						/>
+
+						<div className="flex gap-4">
+							<Button type="submit" disabled={form.formState.isSubmitting}>
+								{form.formState.isSubmitting
+									? "登録中..."
+									: "プロジェクトを登録"}
+							</Button>
+							<Button type="button" variant="outline" asChild>
+								<Link href="/projects">キャンセル</Link>
+							</Button>
+						</div>
+					</form>
+				</Form>
+			</CardContent>
+		</Card>
+	);
+}

--- a/src/components/ui/__tests__/form.test.tsx
+++ b/src/components/ui/__tests__/form.test.tsx
@@ -1,0 +1,140 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useForm } from "react-hook-form";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import {
+	Form,
+	FormControl,
+	FormDescription,
+	FormField,
+	FormItem,
+	FormLabel,
+	FormMessage,
+} from "../form";
+
+// テスト用のフォームスキーマ
+const testSchema = z.object({
+	username: z.string().min(1, "ユーザー名は必須です"),
+	email: z.string().email("有効なメールアドレスを入力してください"),
+});
+
+type TestFormData = z.infer<typeof testSchema>;
+
+// テスト用のフォームコンポーネント
+function TestForm({ onSubmit }: { onSubmit: (data: TestFormData) => void }) {
+	const form = useForm<TestFormData>({
+		resolver: zodResolver(testSchema),
+		defaultValues: {
+			username: "",
+			email: "",
+		},
+	});
+
+	return (
+		<Form {...form}>
+			<form onSubmit={form.handleSubmit(onSubmit)}>
+				<FormField
+					control={form.control}
+					name="username"
+					render={({ field }) => (
+						<FormItem>
+							<FormLabel>ユーザー名</FormLabel>
+							<FormControl>
+								<input {...field} />
+							</FormControl>
+							<FormDescription>
+								アカウントのユーザー名を入力してください
+							</FormDescription>
+							<FormMessage />
+						</FormItem>
+					)}
+				/>
+
+				<FormField
+					control={form.control}
+					name="email"
+					render={({ field }) => (
+						<FormItem>
+							<FormLabel>メールアドレス</FormLabel>
+							<FormControl>
+								<input type="email" {...field} />
+							</FormControl>
+							<FormMessage />
+						</FormItem>
+					)}
+				/>
+
+				<button type="submit">送信</button>
+			</form>
+		</Form>
+	);
+}
+
+describe("Form Components", () => {
+	afterEach(() => {
+		cleanup();
+	});
+
+	it("should render form with all fields and descriptions", () => {
+		const mockSubmit = vi.fn();
+		render(<TestForm onSubmit={mockSubmit} />);
+
+		// フィールドが正しく表示される
+		expect(screen.getByLabelText("ユーザー名")).toBeInTheDocument();
+		expect(screen.getByLabelText("メールアドレス")).toBeInTheDocument();
+
+		// 説明文が表示される
+		expect(
+			screen.getByText("アカウントのユーザー名を入力してください"),
+		).toBeInTheDocument();
+	});
+
+	it("should display validation errors on invalid submission", async () => {
+		const user = userEvent.setup();
+		const mockSubmit = vi.fn();
+		render(<TestForm onSubmit={mockSubmit} />);
+
+		// 空のフォームを送信
+		await user.click(screen.getByRole("button", { name: "送信" }));
+
+		// バリデーションエラーが表示される
+		expect(await screen.findByText("ユーザー名は必須です")).toBeInTheDocument();
+	});
+
+	it("should submit form with valid data", async () => {
+		const user = userEvent.setup();
+		const mockSubmit = vi.fn();
+		render(<TestForm onSubmit={mockSubmit} />);
+
+		// 有効なデータを入力
+		await user.type(screen.getByLabelText("ユーザー名"), "testuser");
+		await user.type(
+			screen.getByLabelText("メールアドレス"),
+			"test@example.com",
+		);
+
+		// フォームを送信
+		await user.click(screen.getByRole("button", { name: "送信" }));
+
+		// 送信関数が正しいデータで呼ばれる
+		expect(mockSubmit).toHaveBeenCalled();
+		expect(mockSubmit.mock.calls[0][0]).toEqual({
+			username: "testuser",
+			email: "test@example.com",
+		});
+	});
+
+	it("should have accessible form structure", () => {
+		const mockSubmit = vi.fn();
+		render(<TestForm onSubmit={mockSubmit} />);
+
+		// ラベルとインプットが正しく関連付けられている
+		const usernameInput = screen.getByLabelText("ユーザー名");
+		expect(usernameInput).toHaveAttribute("aria-describedby");
+
+		// フォーム要素が存在する
+		expect(screen.getByRole("button", { name: "送信" })).toBeInTheDocument();
+	});
+});

--- a/src/components/ui/__tests__/input.test.tsx
+++ b/src/components/ui/__tests__/input.test.tsx
@@ -1,0 +1,30 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it } from "vitest";
+import { Input } from "../input";
+
+describe("Input Component", () => {
+	afterEach(() => {
+		cleanup();
+	});
+
+	it("should accept and display text input", async () => {
+		const user = userEvent.setup();
+		render(<Input placeholder="Enter text" />);
+
+		const input = screen.getByPlaceholderText("Enter text");
+		await user.type(input, "test input");
+
+		expect(input).toHaveValue("test input");
+	});
+
+	it("should support disabled state", () => {
+		render(<Input disabled />);
+		expect(screen.getByRole("textbox")).toBeDisabled();
+	});
+
+	it("should support different input types", () => {
+		render(<Input type="email" />);
+		expect(screen.getByRole("textbox")).toHaveAttribute("type", "email");
+	});
+});

--- a/src/components/ui/__tests__/label.test.tsx
+++ b/src/components/ui/__tests__/label.test.tsx
@@ -1,0 +1,33 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it } from "vitest";
+import { Label } from "../label";
+
+describe("Label Component", () => {
+	afterEach(() => {
+		cleanup();
+	});
+
+	it("should render label with text content", () => {
+		render(<Label>Test Label</Label>);
+		expect(screen.getByText("Test Label")).toBeInTheDocument();
+	});
+
+	it("should associate with input via htmlFor", () => {
+		render(<Label htmlFor="test-input">Test Label</Label>);
+		expect(screen.getByText("Test Label")).toHaveAttribute("for", "test-input");
+	});
+
+	it("should focus input when clicked", async () => {
+		const user = userEvent.setup();
+		render(
+			<div>
+				<Label htmlFor="clickable-input">Clickable Label</Label>
+				<input id="clickable-input" type="text" />
+			</div>,
+		);
+
+		await user.click(screen.getByText("Clickable Label"));
+		expect(screen.getByRole("textbox")).toHaveFocus();
+	});
+});

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import type * as LabelPrimitive from "@radix-ui/react-label";
+import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
+import {
+	Controller,
+	type ControllerProps,
+	type FieldPath,
+	type FieldValues,
+	FormProvider,
+	useFormContext,
+} from "react-hook-form";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+
+const Form = FormProvider;
+
+type FormFieldContextValue<
+	TFieldValues extends FieldValues = FieldValues,
+	TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+> = {
+	name: TName;
+};
+
+const FormFieldContext = React.createContext<FormFieldContextValue>(
+	{} as FormFieldContextValue,
+);
+
+const FormField = <
+	TFieldValues extends FieldValues = FieldValues,
+	TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+>({
+	...props
+}: ControllerProps<TFieldValues, TName>) => {
+	return (
+		<FormFieldContext.Provider value={{ name: props.name }}>
+			<Controller {...props} />
+		</FormFieldContext.Provider>
+	);
+};
+
+const useFormField = () => {
+	const fieldContext = React.useContext(FormFieldContext);
+	const itemContext = React.useContext(FormItemContext);
+	const { getFieldState, formState } = useFormContext();
+
+	const fieldState = getFieldState(fieldContext.name, formState);
+
+	if (!fieldContext) {
+		throw new Error("useFormField should be used within <FormField>");
+	}
+
+	const { id } = itemContext;
+
+	return {
+		id,
+		name: fieldContext.name,
+		formItemId: `${id}-form-item`,
+		formDescriptionId: `${id}-form-item-description`,
+		formMessageId: `${id}-form-item-message`,
+		...fieldState,
+	};
+};
+
+type FormItemContextValue = {
+	id: string;
+};
+
+const FormItemContext = React.createContext<FormItemContextValue>(
+	{} as FormItemContextValue,
+);
+
+const FormItem = React.forwardRef<
+	HTMLDivElement,
+	React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => {
+	const id = React.useId();
+
+	return (
+		<FormItemContext.Provider value={{ id }}>
+			<div ref={ref} className={cn("space-y-2", className)} {...props} />
+		</FormItemContext.Provider>
+	);
+});
+FormItem.displayName = "FormItem";
+
+const FormLabel = React.forwardRef<
+	React.ElementRef<typeof LabelPrimitive.Root>,
+	React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>
+>(({ className, ...props }, ref) => {
+	const { error, formItemId } = useFormField();
+
+	return (
+		<Label
+			ref={ref}
+			className={cn(error && "text-destructive", className)}
+			htmlFor={formItemId}
+			{...props}
+		/>
+	);
+});
+FormLabel.displayName = "FormLabel";
+
+const FormControl = React.forwardRef<
+	React.ElementRef<typeof Slot>,
+	React.ComponentPropsWithoutRef<typeof Slot>
+>(({ ...props }, ref) => {
+	const { error, formItemId, formDescriptionId, formMessageId } =
+		useFormField();
+
+	return (
+		<Slot
+			ref={ref}
+			id={formItemId}
+			aria-describedby={
+				!error
+					? `${formDescriptionId}`
+					: `${formDescriptionId} ${formMessageId}`
+			}
+			aria-invalid={!!error}
+			{...props}
+		/>
+	);
+});
+FormControl.displayName = "FormControl";
+
+const FormDescription = React.forwardRef<
+	HTMLParagraphElement,
+	React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => {
+	const { formDescriptionId } = useFormField();
+
+	return (
+		<p
+			ref={ref}
+			id={formDescriptionId}
+			className={cn("text-sm text-muted-foreground", className)}
+			{...props}
+		/>
+	);
+});
+FormDescription.displayName = "FormDescription";
+
+const FormMessage = React.forwardRef<
+	HTMLParagraphElement,
+	React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, children, ...props }, ref) => {
+	const { error, formMessageId } = useFormField();
+	const body = error ? String(error?.message) : children;
+
+	if (!body) {
+		return null;
+	}
+
+	return (
+		<p
+			ref={ref}
+			id={formMessageId}
+			className={cn("text-sm font-medium text-destructive", className)}
+			{...props}
+		>
+			{body}
+		</p>
+	);
+});
+FormMessage.displayName = "FormMessage";
+
+export {
+	useFormField,
+	Form,
+	FormItem,
+	FormLabel,
+	FormControl,
+	FormDescription,
+	FormMessage,
+	FormField,
+};

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,25 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface InputProps
+	extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+	({ className, type, ...props }, ref) => {
+		return (
+			<input
+				type={type}
+				className={cn(
+					"flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+					className,
+				)}
+				ref={ref}
+				{...props}
+			/>
+		);
+	},
+);
+Input.displayName = "Input";
+
+export { Input };

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import * as LabelPrimitive from "@radix-ui/react-label";
+import { cva, type VariantProps } from "class-variance-authority";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const labelVariants = cva(
+	"text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+);
+
+const Label = React.forwardRef<
+	React.ElementRef<typeof LabelPrimitive.Root>,
+	React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
+		VariantProps<typeof labelVariants>
+>(({ className, ...props }, ref) => (
+	<LabelPrimitive.Root
+		ref={ref}
+		className={cn(labelVariants(), className)}
+		{...props}
+	/>
+));
+Label.displayName = LabelPrimitive.Root.displayName;
+
+export { Label };

--- a/src/database/__tests__/connection.test.ts
+++ b/src/database/__tests__/connection.test.ts
@@ -99,7 +99,6 @@ describe("connection.ts", () => {
 
 			try {
 				await transaction(async () => {
-					const repo = new ProjectsRepository();
 					await createProject({
 						name: "Will be rolled back",
 						gitlab_id: 11001,
@@ -167,7 +166,6 @@ describe("connection.ts", () => {
 
 			try {
 				await transaction(async () => {
-					const repo = new ProjectsRepository();
 					await createProject({
 						name: "Outer Before Error",
 						gitlab_id: 12004,

--- a/src/lib/validation/__tests__/project-schemas.test.ts
+++ b/src/lib/validation/__tests__/project-schemas.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { projectRegistrationSchema } from "../project-schemas";
+
+describe("projectRegistrationSchema", () => {
+	describe("URL validation", () => {
+		it("should require URL field", () => {
+			const result = projectRegistrationSchema.safeParse({ url: "" });
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				expect(result.error.errors[0].message).toBe("URLは必須です");
+			}
+		});
+
+		it("should validate URL format", () => {
+			const result = projectRegistrationSchema.safeParse({
+				url: "invalid-url",
+			});
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				expect(
+					result.error.errors.some(
+						(e) => e.message === "有効なURLを入力してください",
+					),
+				).toBe(true);
+			}
+		});
+
+		it("should validate URL length", () => {
+			const longUrl = `https://gitlab.com/${"a".repeat(500)}`;
+			const result = projectRegistrationSchema.safeParse({ url: longUrl });
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				expect(
+					result.error.errors.some(
+						(e) => e.message === "URLは500文字以内で入力してください",
+					),
+				).toBe(true);
+			}
+		});
+
+		it("should validate GitLab project URL format", () => {
+			const invalidUrls = [
+				"https://gitlab.com/singlepath",
+				"https://github.com/user/repo",
+				"https://example.com/some/path",
+			];
+
+			for (const url of invalidUrls) {
+				const result = projectRegistrationSchema.safeParse({ url });
+				expect(result.success).toBe(false);
+				if (!result.success) {
+					expect(
+						result.error.errors.some(
+							(e) =>
+								e.message === "GitLabプロジェクトの有効なURLを入力してください",
+						),
+					).toBe(true);
+				}
+			}
+		});
+
+		it("should accept valid GitLab project URLs", () => {
+			const validUrls = [
+				"https://gitlab.com/group/project",
+				"https://gitlab.example.com/group/subgroup/project",
+				"https://gitlab.com/user/my-project",
+			];
+
+			for (const url of validUrls) {
+				const result = projectRegistrationSchema.safeParse({ url });
+				expect(result.success).toBe(true);
+			}
+		});
+	});
+});

--- a/src/lib/validation/project-schemas.ts
+++ b/src/lib/validation/project-schemas.ts
@@ -1,0 +1,38 @@
+import { z } from "zod";
+
+/**
+ * プロジェクト登録用バリデーションスキーマ
+ * クライアントサイドとサーバーサイドで共通使用
+ */
+export const projectRegistrationSchema = z.object({
+	url: z
+		.string()
+		.min(1, "URLは必須です")
+		.url("有効なURLを入力してください")
+		.max(500, "URLは500文字以内で入力してください")
+		.refine(
+			(url) => {
+				try {
+					const urlObj = new URL(url);
+					const pathSegments = urlObj.pathname.split("/").filter(Boolean);
+
+					// GitLabドメインかどうかチェック（gitlab.comまたは任意のgitlabサブドメイン/ホスト）
+					const isGitLabDomain =
+						urlObj.hostname === "gitlab.com" ||
+						urlObj.hostname.includes("gitlab");
+
+					// GitLabプロジェクトのパス形式: /group/project または /group/subgroup/project
+					const hasValidPath = pathSegments.length >= 2;
+
+					return isGitLabDomain && hasValidPath;
+				} catch {
+					return false;
+				}
+			},
+			{
+				message: "GitLabプロジェクトの有効なURLを入力してください",
+			},
+		),
+});
+
+export type ProjectRegistrationData = z.infer<typeof projectRegistrationSchema>;


### PR DESCRIPTION
- GitLabプロジェクトURLから情報を取得・登録する機能を追加
- react-hook-formとZodを使用したフォームバリデーション
- 新規プロジェクト登録ページ(/projects/new)を実装
- プロジェクト一覧ページに登録ボタンを追加
- 包括的なテストカバレッジを実装
- shadcn/uiコンポーネント(form, input, label)を追加

🤖 Generated with [Claude Code](https://claude.ai/code)