### PR TITLE
GitLabApiClientの設計を簡素化

### DIFF
--- a/src/api/__tests__/gitlab-client.test.ts
+++ b/src/api/__tests__/gitlab-client.test.ts
@@ -93,7 +93,7 @@ describe("GitLabApiClient", () => {
 		let client: GitLabApiClient;
 
 		beforeEach(() => {
-			client = new GitLabApiClient(mockConfig);
+			client = new GitLabApiClient();
 		});
 
 		it("現在のユーザー情報を正常に取得できる", async () => {
@@ -116,7 +116,7 @@ describe("GitLabApiClient", () => {
 		let client: GitLabApiClient;
 
 		beforeEach(() => {
-			client = new GitLabApiClient(mockConfig);
+			client = new GitLabApiClient();
 		});
 
 		it("プロジェクト情報を正常に取得できる", async () => {
@@ -141,7 +141,7 @@ describe("GitLabApiClient", () => {
 		let client: GitLabApiClient;
 
 		beforeEach(() => {
-			client = new GitLabApiClient(mockConfig);
+			client = new GitLabApiClient();
 		});
 
 		it("接続成功時にtrueを返す", async () => {
@@ -166,7 +166,7 @@ describe("GitLabApiClient", () => {
 		let client: GitLabApiClient;
 
 		beforeEach(() => {
-			client = new GitLabApiClient(mockConfig);
+			client = new GitLabApiClient();
 		});
 
 		it("プロジェクトのコミット一覧を正常に取得できる（ジェネレータ）", async () => {
@@ -287,7 +287,7 @@ describe("GitLabApiClient", () => {
 		let client: GitLabApiClient;
 
 		beforeEach(() => {
-			client = new GitLabApiClient(mockConfig);
+			client = new GitLabApiClient();
 		});
 
 		it("APIエラー時にErrorを投げる", async () => {


### PR DESCRIPTION
- コンストラクタから引数を削除し、内部でloadConfig()を自動実行
- getClient()メソッドパターンで遅延初期化を実装
- 設定のtimeout値の冗長性を解消
- テストコードをコンストラクタ変更に対応

🤖 Generated with [Claude Code](https://claude.ai/code)