### PR TITLE
CI環境でのlint設定を改善してコード品質を向上

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"start:web": "next start",
 		"test": "vitest run",
 		"test:watch": "vitest",
-		"lint": "biome check .",
+		"lint": "biome ci .",
 		"lint:fix": "biome check --write .",
 		"format": "biome format --write .",
 		"all": "npm run lint && npm run typecheck && npm run test && npm run build",

--- a/src/api/__tests__/gitlab-client.test.ts
+++ b/src/api/__tests__/gitlab-client.test.ts
@@ -60,11 +60,6 @@ function createMockCommits(
 }
 
 describe("GitLabApiClient", () => {
-	const mockConfig = {
-		baseUrl: "https://gitlab.example.com",
-		token: "test-token",
-	};
-
 	const mockAxiosInstance = {
 		get: vi.fn(),
 		post: vi.fn(),

--- a/src/api/gitlab-client.ts
+++ b/src/api/gitlab-client.ts
@@ -11,7 +11,6 @@ import type {
 import axios from "axios";
 import { loadConfig } from "@/config/index";
 import type { GitLabCommit, GitLabCommitsQuery } from "./types/commit";
-import type { GitLabClientConfig } from "./types/common";
 import type { GitLabProject } from "./types/project";
 import type { GitLabUser } from "./types/user";
 

--- a/src/database/connection.ts
+++ b/src/database/connection.ts
@@ -38,7 +38,10 @@ export async function getDb() {
 	if (!_db) {
 		await initializeDatabase();
 	}
-	return _db!;
+	if (!_db) {
+		throw new Error("Failed to initialize database");
+	}
+	return _db;
 }
 
 /**
@@ -48,7 +51,10 @@ export async function getPool() {
 	if (!_pool) {
 		await initializeDatabase();
 	}
-	return _pool!;
+	if (!_pool) {
+		throw new Error("Failed to initialize database pool");
+	}
+	return _pool;
 }
 
 // データベース接続テスト

--- a/src/database/repositories/base.ts
+++ b/src/database/repositories/base.ts
@@ -20,6 +20,9 @@ export abstract class BaseRepository {
 		if (!this.db) {
 			this.db = (await getDb()) as unknown as NodePgDatabase<typeof schema>;
 		}
-		return this.db!;
+		if (!this.db) {
+			throw new Error("Failed to get database instance");
+		}
+		return this.db;
 	}
 }

--- a/src/database/repositories/commits.ts
+++ b/src/database/repositories/commits.ts
@@ -1,11 +1,9 @@
 import { and, count, desc, eq } from "drizzle-orm";
-import type { NodePgDatabase } from "drizzle-orm/node-postgres";
 import {
 	type Commit,
 	commits,
 	type NewCommit,
 } from "@/database/schema/commits";
-import type * as schema from "@/database/schema/index";
 import { BaseRepository } from "./base";
 
 /**

--- a/src/database/repositories/projects.ts
+++ b/src/database/repositories/projects.ts
@@ -1,6 +1,4 @@
 import { asc, count, eq } from "drizzle-orm";
-import type { NodePgDatabase } from "drizzle-orm/node-postgres";
-import type * as schema from "@/database/schema/index";
 import {
 	type NewProject,
 	type Project,

--- a/src/database/repositories/sync-logs.ts
+++ b/src/database/repositories/sync-logs.ts
@@ -1,11 +1,9 @@
 import { and, count, desc, eq } from "drizzle-orm";
-import type { NodePgDatabase } from "drizzle-orm/node-postgres";
 import type {
 	CompleteSyncParams,
 	FailSyncParams,
 	FindSyncLogsParams,
 } from "@/database/repositories/types/sync-logs";
-import type * as schema from "@/database/schema/index";
 import {
 	type NewSyncLog,
 	SYNC_STATUSES,


### PR DESCRIPTION
- npm run lintでbiome ciを使用するよう変更（開発・CI環境統一）
- 未使用変数・インポートを削除してlint警告を解消
- non-null assertionを安全なエラーハンドリングに置き換え
- CI環境でlint警告時に確実にビルドが失敗するよう設定

🤖 Generated with [Claude Code](https://claude.ai/code)