### PR TITLE
Dockerコンテナでマウントされた.gitconfigとの互換性向上

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ ENV LC_ALL=ja_JP.UTF-8
 WORKDIR /app
 
 # Git credential helper設定（環境変数からGitHubトークンを使用）
-RUN git config --global credential.helper '!f() { echo "username=token"; echo "password=$GITHUB_TOKEN"; }; f'
+RUN git config --system credential.helper '!f() { echo "username=token"; echo "password=$GITHUB_TOKEN"; }; f'
 
 # アプリケーションポートを公開
 EXPOSE 8080


### PR DESCRIPTION
## 概要
- Dockerコンテナ内でユーザーの`.gitconfig`をマウントした際の互換性を向上
- Git credential helperの設定を`--global`から`--system`に変更

## 変更内容
- `Dockerfile`内のgit config設定を修正
  - `git config --global` → `git config --system`
  
## テスト方法
- [x] Dockerイメージをビルドして正常に動作することを確認
- [x] コンテナ内でGit認証が適切に機能することを確認
- [x] ユーザーの`.gitconfig`をマウントした状態でも認証情報が利用できることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)