### PR TITLE
テストのdescribe構成を整理

### DIFF
--- a/src/app/projects/__tests__/actions.test.ts
+++ b/src/app/projects/__tests__/actions.test.ts
@@ -25,151 +25,165 @@ vi.mock("@/api/gitlab-client");
 const mockGitLabApiClient = vi.mocked(GitLabApiClient);
 const mockRedirect = vi.mocked(redirect);
 
-describe("getProjects Server Action", () => {
+describe("actions.tsx", () => {
 	afterAll(async () => {
 		await closeConnection();
 	});
 
-	afterEach(() => {
-		// すべてのモックを自動復元
-		vi.restoreAllMocks();
-	});
-
-	it("プロジェクト一覧を正常に取得できる", async () => {
-		await withTransaction(async () => {
-			// テストデータを作成
-			await createProject({ name: "プロジェクトA" });
-			await createProject({ name: "プロジェクトB" });
-
-			// Server Actionを実行
-			const result = await getProjects();
-
-			// プロジェクトが取得できることを確認
-			expect(result).toHaveLength(2);
-			expect(result.map((p) => p.name)).toEqual([
-				"プロジェクトA",
-				"プロジェクトB",
-			]);
+	describe("getProjects", () => {
+		afterEach(() => {
+			// すべてのモックを自動復元
+			vi.restoreAllMocks();
 		});
-	});
 
-	it("データベースエラー時に適切なエラーを投げる", async () => {
-		// projectsRepositoryのfindAllメソッドを直接モック
-		const { projectsRepository } = await import("@/database/index");
-		const originalFindAll = projectsRepository.findAll;
+		it("プロジェクト一覧を正常に取得できる", async () => {
+			await withTransaction(async () => {
+				// テストデータを作成
+				await createProject({ name: "プロジェクトA" });
+				await createProject({ name: "プロジェクトB" });
 
-		// 一時的にエラーを投げるようにモック
-		projectsRepository.findAll = vi
-			.fn()
-			.mockRejectedValue(new Error("Database connection failed"));
+				// Server Actionを実行
+				const result = await getProjects();
 
-		try {
-			// エラーが適切に投げられることを確認
-			await expect(getProjects()).rejects.toThrow(
-				"プロジェクト一覧の取得に失敗しました",
-			);
-		} finally {
-			// 元のメソッドに戻す
-			projectsRepository.findAll = originalFindAll;
-		}
-	});
-});
+				// プロジェクトが取得できることを確認
+				expect(result).toHaveLength(2);
+				expect(result.map((p) => p.name)).toEqual([
+					"プロジェクトA",
+					"プロジェクトB",
+				]);
+			});
+		});
 
-describe("registerProject Server Action", () => {
-	afterAll(async () => {
-		await closeConnection();
-	});
-
-	const mockFormData = (url: string) => {
-		const formData = new FormData();
-		formData.append("url", url);
-		return formData;
-	};
-
-	const mockGitLabProject = {
-		id: 123,
-		name: "test-project",
-		description: "Test project description",
-		web_url: "https://gitlab.example.com/group/test-project",
-		default_branch: "main",
-		visibility: "private" as const,
-		created_at: "2023-01-01T00:00:00Z",
-	};
-
-	beforeEach(() => {
-		vi.clearAllMocks();
-
-		// GitLab APIクライアントのモック
-		const mockClient: Partial<GitLabApiClientType> = {
-			getProject: vi.fn().mockResolvedValue(mockGitLabProject),
-		};
-		mockGitLabApiClient.mockReturnValue(mockClient as GitLabApiClientType);
-	});
-
-	it("should successfully register a new project", async () => {
-		await withTransaction(async () => {
-			const formData = mockFormData(
-				"https://gitlab.example.com/group/test-project",
-			);
-
-			// プロジェクト登録を実行
-			await registerProject(null, formData);
-
-			// redirectが呼ばれたことを確認
-			expect(mockRedirect).toHaveBeenCalledWith("/projects");
-
-			// データベースにプロジェクトが登録されたことを確認
+		it("データベースエラー時に適切なエラーを投げる", async () => {
+			// projectsRepositoryのfindAllメソッドを直接モック
 			const { projectsRepository } = await import("@/database/index");
-			const projects = await projectsRepository.findAll();
+			const originalFindAll = projectsRepository.findAll;
 
-			expect(projects).toHaveLength(1);
-			expect(projects[0]).toMatchObject({
-				gitlab_id: mockGitLabProject.id,
-				name: mockGitLabProject.name,
-				description: mockGitLabProject.description,
-				web_url: mockGitLabProject.web_url,
-				default_branch: mockGitLabProject.default_branch,
-				visibility: mockGitLabProject.visibility,
-			});
+			// 一時的にエラーを投げるようにモック
+			projectsRepository.findAll = vi
+				.fn()
+				.mockRejectedValue(new Error("Database connection failed"));
+
+			try {
+				// エラーが適切に投げられることを確認
+				await expect(getProjects()).rejects.toThrow(
+					"プロジェクト一覧の取得に失敗しました",
+				);
+			} finally {
+				// 元のメソッドに戻す
+				projectsRepository.findAll = originalFindAll;
+			}
 		});
 	});
 
-	it("should return error for invalid URL", async () => {
-		const formData = mockFormData("invalid-url");
+	describe("registerProject", () => {
+		const mockFormData = (url: string) => {
+			const formData = new FormData();
+			formData.append("url", url);
+			return formData;
+		};
 
-		const result = await registerProject(null, formData);
+		const mockGitLabProject = {
+			id: 123,
+			name: "test-project",
+			description: "Test project description",
+			web_url: "https://gitlab.example.com/group/test-project",
+			default_branch: "main",
+			visibility: "private" as const,
+			created_at: "2023-01-01T00:00:00Z",
+		};
 
-		expect(result.success).toBe(false);
-		expect(result.error).toContain("有効なURL");
-	});
+		beforeEach(() => {
+			vi.clearAllMocks();
 
-	it("should return error for empty URL", async () => {
-		const formData = mockFormData("");
+			// GitLab APIクライアントのモック
+			const mockClient: Partial<GitLabApiClientType> = {
+				getProject: vi.fn().mockResolvedValue(mockGitLabProject),
+			};
+			mockGitLabApiClient.mockReturnValue(mockClient as GitLabApiClientType);
+		});
 
-		const result = await registerProject(null, formData);
+		it("should successfully register a new project", async () => {
+			await withTransaction(async () => {
+				const formData = mockFormData(
+					"https://gitlab.example.com/group/test-project",
+				);
 
-		expect(result.success).toBe(false);
-		expect(result.error).toBe("URLは必須です");
-	});
+				// プロジェクト登録を実行
+				await registerProject(null, formData);
 
-	it("should return error for non-GitLab URL", async () => {
-		const formData = mockFormData("https://github.com/user/repo");
+				// redirectが呼ばれたことを確認
+				expect(mockRedirect).toHaveBeenCalledWith("/projects");
 
-		const result = await registerProject(null, formData);
+				// データベースにプロジェクトが登録されたことを確認
+				const { projectsRepository } = await import("@/database/index");
+				const projects = await projectsRepository.findAll();
 
-		expect(result.success).toBe(false);
-		expect(result.error).toBe(
-			"GitLabプロジェクトの有効なURLを入力してください",
-		);
-	});
-
-	it("should return error when project already exists", async () => {
-		await withTransaction(async () => {
-			// 既存プロジェクトを作成
-			await createProject({
-				gitlab_id: mockGitLabProject.id,
-				name: mockGitLabProject.name,
+				expect(projects).toHaveLength(1);
+				expect(projects[0]).toMatchObject({
+					gitlab_id: mockGitLabProject.id,
+					name: mockGitLabProject.name,
+					description: mockGitLabProject.description,
+					web_url: mockGitLabProject.web_url,
+					default_branch: mockGitLabProject.default_branch,
+					visibility: mockGitLabProject.visibility,
+				});
 			});
+		});
+
+		it("should return error for invalid URL", async () => {
+			const formData = mockFormData("invalid-url");
+
+			const result = await registerProject(null, formData);
+
+			expect(result.success).toBe(false);
+			expect(result.error).toContain("有効なURL");
+		});
+
+		it("should return error for empty URL", async () => {
+			const formData = mockFormData("");
+
+			const result = await registerProject(null, formData);
+
+			expect(result.success).toBe(false);
+			expect(result.error).toBe("URLは必須です");
+		});
+
+		it("should return error for non-GitLab URL", async () => {
+			const formData = mockFormData("https://github.com/user/repo");
+
+			const result = await registerProject(null, formData);
+
+			expect(result.success).toBe(false);
+			expect(result.error).toBe(
+				"GitLabプロジェクトの有効なURLを入力してください",
+			);
+		});
+
+		it("should return error when project already exists", async () => {
+			await withTransaction(async () => {
+				// 既存プロジェクトを作成
+				await createProject({
+					gitlab_id: mockGitLabProject.id,
+					name: mockGitLabProject.name,
+				});
+
+				const formData = mockFormData(
+					"https://gitlab.example.com/group/test-project",
+				);
+
+				const result = await registerProject(null, formData);
+
+				expect(result.success).toBe(false);
+				expect(result.error).toBe("このプロジェクトは既に登録されています");
+			});
+		});
+
+		it("should handle GitLab API errors", async () => {
+			const mockClient: Partial<GitLabApiClientType> = {
+				getProject: vi.fn().mockRejectedValue(new Error("GitLab API error")),
+			};
+			mockGitLabApiClient.mockReturnValue(mockClient as GitLabApiClientType);
 
 			const formData = mockFormData(
 				"https://gitlab.example.com/group/test-project",
@@ -178,23 +192,7 @@ describe("registerProject Server Action", () => {
 			const result = await registerProject(null, formData);
 
 			expect(result.success).toBe(false);
-			expect(result.error).toBe("このプロジェクトは既に登録されています");
+			expect(result.error).toBe("GitLab API error");
 		});
-	});
-
-	it("should handle GitLab API errors", async () => {
-		const mockClient: Partial<GitLabApiClientType> = {
-			getProject: vi.fn().mockRejectedValue(new Error("GitLab API error")),
-		};
-		mockGitLabApiClient.mockReturnValue(mockClient as GitLabApiClientType);
-
-		const formData = mockFormData(
-			"https://gitlab.example.com/group/test-project",
-		);
-
-		const result = await registerProject(null, formData);
-
-		expect(result.success).toBe(false);
-		expect(result.error).toBe("GitLab API error");
 	});
 });


### PR DESCRIPTION
## Summary
- actions.test.tsのdescribe構成をより論理的に整理
- ルートを "actions.tsx" にし、各メソッドを子要素として配置
- テストの内容は変更せず、可読性とメンテナンス性を向上

## Test plan
- [x] 既存のテストが正常に動作することを確認
- [x] describe構成が適切に階層化されていることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)