### PR TITLE
不要なCORSヘッダーテストを削除

### DIFF
--- a/src/__tests__/middleware.test.ts
+++ b/src/__tests__/middleware.test.ts
@@ -15,24 +15,6 @@ describe("セキュリティミドルウェア", () => {
 		);
 	});
 
-	it("どのルートでもCORSヘッダーを設定しない", async () => {
-		const routes = [
-			"http://localhost:3000/",
-			"http://localhost:3000/api/health",
-			"http://localhost:3000/health",
-			"http://localhost:3000/about",
-		];
-
-		for (const url of routes) {
-			const request = new NextRequest(url);
-			const response = await middleware(request);
-
-			expect(response.headers.get("Access-Control-Allow-Origin")).toBeNull();
-			expect(response.headers.get("Access-Control-Allow-Methods")).toBeNull();
-			expect(response.headers.get("Access-Control-Allow-Headers")).toBeNull();
-		}
-	});
-
 	it("すべてのルートで基本セキュリティヘッダーを設定する", async () => {
 		const routes = [
 			"http://localhost:3000/",

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server";
 
-export function middleware(request: NextRequest) {
+export function middleware(_request: NextRequest) {
 	// Create response
 	const response = NextResponse.next();
 


### PR DESCRIPTION
## Summary
- ミドルウェアから「どのルートでもCORSヘッダーを設定しない」テストを削除
- CORS設定コードが存在しないため、このテストは不必要
- セキュリティヘッダーのテストで十分にミドルウェアの動作を確認可能

## Test plan
- [x] ミドルウェアテストが正常に実行される
- [x] セキュリティヘッダーの設定が正しくテストされる
- [x] 不要なテストが削除されていることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)