### PR TITLE
CIでのlint警告をエラー扱いに変更

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"start:web": "next start",
 		"test": "vitest run",
 		"test:watch": "vitest",
-		"lint": "biome ci .",
+		"lint": "biome ci . --error-on-warnings",
 		"lint:fix": "biome check --write .",
 		"format": "biome format --write .",
 		"all": "npm run lint && npm run typecheck && npm run test && npm run build",


### PR DESCRIPTION
## Summary
- package.jsonのlintスクリプトに`--error-on-warnings`フラグを追加
- CIで警告が出た場合にビルドが失敗するように修正

## 背景
現在のCIでは、`biome ci`コマンドで警告が出ても終了ステータス0（成功）を返すため、「Lint成功」として扱われてしまっています。これにより、コード品質の問題が見過ごされる可能性がありました。

## 変更内容
- `package.json`の`lint`スクリプトを`biome ci . --error-on-warnings`に変更
- これにより警告が出た場合も終了ステータス1（エラー）を返すようになり、CIが適切に失敗します

## Test plan
- [x] ローカルでlintコマンドが正常に動作することを確認
- [ ] PRをマージ後、CIで警告があった場合に適切に失敗することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)