### PR TITLE
sync_logsテーブルから不要なカラムを削除

### DIFF
--- a/src/database/migrations/0006_real_ghost_rider.sql
+++ b/src/database/migrations/0006_real_ghost_rider.sql
@@ -1,0 +1,5 @@
+DROP INDEX "sync_logs_project_type_completed_idx";--> statement-breakpoint
+CREATE INDEX "sync_logs_project_type_created_idx" ON "sync_logs" USING btree ("project_id","sync_type","created_at");--> statement-breakpoint
+ALTER TABLE "sync_logs" DROP COLUMN "completed_at";--> statement-breakpoint
+ALTER TABLE "sync_logs" DROP COLUMN "records_processed";--> statement-breakpoint
+ALTER TABLE "sync_logs" DROP COLUMN "records_added";

--- a/src/database/migrations/meta/0006_snapshot.json
+++ b/src/database/migrations/meta/0006_snapshot.json
@@ -1,0 +1,369 @@
+{
+  "id": "9086c3d0-3c59-4798-b9b7-00f5f9eefba3",
+  "prevId": "7b2f8c9d-3e4a-5678-90ab-cdef12345678",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.commits": {
+      "name": "commits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha": {
+          "name": "sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_email": {
+          "name": "author_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_date": {
+          "name": "author_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "additions": {
+          "name": "additions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletions": {
+          "name": "deletions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "commits_project_sha_unique": {
+          "name": "commits_project_sha_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "commits_project_id_idx": {
+          "name": "commits_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "commits_author_email_idx": {
+          "name": "commits_author_email_idx",
+          "columns": [
+            {
+              "expression": "author_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "commits_author_date_idx": {
+          "name": "commits_author_date_idx",
+          "columns": [
+            {
+              "expression": "author_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "commits_project_id_projects_id_fk": {
+          "name": "commits_project_id_projects_id_fk",
+          "tableFrom": "commits",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "gitlab_id": {
+          "name": "gitlab_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "web_url": {
+          "name": "web_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "gitlab_created_at": {
+          "name": "gitlab_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "projects_gitlab_id_unique": {
+          "name": "projects_gitlab_id_unique",
+          "columns": [
+            {
+              "expression": "gitlab_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_name_idx": {
+          "name": "projects_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_logs": {
+      "name": "sync_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_type": {
+          "name": "sync_type",
+          "type": "sync_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_item_date": {
+          "name": "last_item_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sync_logs_project_type_created_idx": {
+          "name": "sync_logs_project_type_created_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sync_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sync_logs_project_id_projects_id_fk": {
+          "name": "sync_logs_project_id_projects_id_fk",
+          "tableFrom": "sync_logs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.sync_type": {
+      "name": "sync_type",
+      "schema": "public",
+      "values": [
+        "projects",
+        "commits"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/database/migrations/meta/_journal.json
+++ b/src/database/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1754222156789,
       "tag": "0005_rename_last_commit_date_to_last_item_date",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1754245799489,
+      "tag": "0006_real_ghost_rider",
+      "breakpoints": true
     }
   ]
 }

--- a/src/database/repositories/__tests__/sync-logs.test.ts
+++ b/src/database/repositories/__tests__/sync-logs.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, describe, expect, it } from "vitest";
 import { closeConnection } from "@/database/connection";
 import { syncLogsRepository } from "@/database/repositories";
-import { SYNC_TYPES, type SyncLog } from "@/database/schema/sync-logs";
+import { SYNC_TYPES } from "@/database/schema/sync-logs";
 import {
 	buildNewSyncLog,
 	createProject,
@@ -26,7 +26,6 @@ describe("Sync Logs Repository", () => {
 				const syncLogData = buildNewSyncLog({
 					project_id: project.id,
 					sync_type: SYNC_TYPES.PROJECTS,
-					completed_at: new Date(),
 				});
 
 				const syncLog = await syncLogsRepository.create(syncLogData);
@@ -35,9 +34,6 @@ describe("Sync Logs Repository", () => {
 				expect(syncLog.id).toBeDefined();
 				expect(syncLog.project_id).toBe(project.id);
 				expect(syncLog.sync_type).toBe(SYNC_TYPES.PROJECTS);
-				expect(syncLog.completed_at).toBeDefined();
-				expect(syncLog.records_processed).toBeDefined();
-				expect(syncLog.records_added).toBeDefined();
 				expect(syncLog.last_item_date).toBeDefined();
 				expect(syncLog.created_at).toBeDefined();
 			});
@@ -51,7 +47,6 @@ describe("Sync Logs Repository", () => {
 				const syncLogData = buildNewSyncLog({
 					project_id: project.id,
 					sync_type: SYNC_TYPES.COMMITS,
-					completed_at: new Date(),
 				});
 
 				const syncLog = await syncLogsRepository.create(syncLogData);
@@ -64,7 +59,6 @@ describe("Sync Logs Repository", () => {
 			await withTransaction(async () => {
 				const syncLogData = buildNewSyncLog({
 					project_id: 999999, // 存在しないプロジェクトID
-					completed_at: new Date(),
 				});
 
 				await expect(syncLogsRepository.create(syncLogData)).rejects.toThrow();
@@ -105,19 +99,16 @@ describe("Sync Logs Repository", () => {
 				const project = await createProject();
 
 				// 複数の同期ログを作成
-				await createSyncLogs(3, {
-					project_id: project.id,
-					completed_at: new Date(),
-				});
+				await createSyncLogs(3, { project_id: project.id });
 
 				const logs = await syncLogsRepository.find();
 
 				expect(Array.isArray(logs)).toBe(true);
 				expect(logs.length).toBeGreaterThanOrEqual(3);
 
-				// completed_at降順でソートされているかチェック
+				// created_at降順でソートされているかチェック
 				for (let i = 1; i < logs.length; i++) {
-					expect(logs[i].completed_at <= logs[i - 1].completed_at).toBe(true);
+					expect(logs[i].created_at <= logs[i - 1].created_at).toBe(true);
 				}
 			});
 		});
@@ -129,14 +120,8 @@ describe("Sync Logs Repository", () => {
 				const project2 = await createProject();
 
 				// 各プロジェクトで同期ログを作成
-				await createSyncLog({
-					project_id: project1.id,
-					completed_at: new Date(),
-				});
-				await createSyncLog({
-					project_id: project2.id,
-					completed_at: new Date(),
-				});
+				await createSyncLog({ project_id: project1.id });
+				await createSyncLog({ project_id: project2.id });
 
 				const logs = await syncLogsRepository.find({
 					project_id: project1.id,
@@ -158,12 +143,10 @@ describe("Sync Logs Repository", () => {
 				await createSyncLog({
 					project_id: project.id,
 					sync_type: SYNC_TYPES.PROJECTS,
-					completed_at: new Date(),
 				});
 				await createSyncLog({
 					project_id: project.id,
 					sync_type: SYNC_TYPES.COMMITS,
-					completed_at: new Date(),
 				});
 
 				const projectsLogs = await syncLogsRepository.find({
@@ -191,10 +174,7 @@ describe("Sync Logs Repository", () => {
 				const project = await createProject();
 
 				// 複数の同期ログを作成
-				await createSyncLogs(5, {
-					project_id: project.id,
-					completed_at: new Date(),
-				});
+				await createSyncLogs(5, { project_id: project.id });
 
 				const firstPage = await syncLogsRepository.find({
 					project_id: project.id,
@@ -225,10 +205,7 @@ describe("Sync Logs Repository", () => {
 				const project = await createProject();
 
 				// 同期ログを作成
-				await createSyncLog({
-					project_id: project.id,
-					completed_at: new Date(),
-				});
+				await createSyncLog({ project_id: project.id });
 
 				const logs = await syncLogsRepository.findByProject(project.id);
 
@@ -246,10 +223,7 @@ describe("Sync Logs Repository", () => {
 				const project = await createProject();
 
 				// 複数の同期ログを作成
-				await createSyncLogs(5, {
-					project_id: project.id,
-					completed_at: new Date(),
-				});
+				await createSyncLogs(5, { project_id: project.id });
 
 				const limitedLogs = await syncLogsRepository.findByProject(
 					project.id,
@@ -268,21 +242,16 @@ describe("Sync Logs Repository", () => {
 				// テスト用プロジェクトを作成
 				const project = await createProject();
 
-				// 複数の同期ログを作成（時間をずらして）
-				const baseTime = new Date();
-				let lastStarted: SyncLog | undefined;
-				for (let i = 0; i < 3; i++) {
-					lastStarted = await createSyncLog({
-						project_id: project.id,
-						completed_at: new Date(baseTime.getTime() + i * 1000), // 1秒ずつずらす
-					});
-				}
+				// 複数の同期ログを作成し、配列で保存
+				const createdLogs = await createSyncLogs(3, { project_id: project.id });
 
 				const latest = await syncLogsRepository.findLatest(project.id);
 
 				expect(latest).toBeDefined();
 				expect(latest?.project_id).toBe(project.id);
-				expect(latest?.id).toBe(lastStarted?.id);
+
+				// 最後に作成されたログと比較
+				expect(latest?.id).toBe(createdLogs[2].id);
 			});
 		});
 
@@ -292,16 +261,13 @@ describe("Sync Logs Repository", () => {
 				const project = await createProject();
 
 				// 異なるタイプの同期ログを作成
-				const baseTime = new Date();
 				await createSyncLog({
 					project_id: project.id,
 					sync_type: SYNC_TYPES.PROJECTS,
-					completed_at: baseTime,
 				});
 				await createSyncLog({
 					project_id: project.id,
 					sync_type: SYNC_TYPES.COMMITS,
-					completed_at: new Date(baseTime.getTime() + 1000), // 1秒後
 				});
 
 				const latestProjects = await syncLogsRepository.findLatest(
@@ -339,10 +305,7 @@ describe("Sync Logs Repository", () => {
 				const initialCount = await syncLogsRepository.count();
 
 				// 同期ログを作成
-				await createSyncLog({
-					project_id: project.id,
-					completed_at: new Date(),
-				});
+				await createSyncLog({ project_id: project.id });
 
 				const newCount = await syncLogsRepository.count();
 				expect(newCount).toBe(initialCount + 1);
@@ -360,16 +323,10 @@ describe("Sync Logs Repository", () => {
 				});
 
 				// プロジェクト1の同期ログを作成
-				await createSyncLog({
-					project_id: project1.id,
-					completed_at: new Date(),
-				});
+				await createSyncLog({ project_id: project1.id });
 
 				// プロジェクト2の同期ログを作成
-				await createSyncLog({
-					project_id: project2.id,
-					completed_at: new Date(),
-				});
+				await createSyncLog({ project_id: project2.id });
 
 				const newCount1 = await syncLogsRepository.count({
 					project_id: project1.id,
@@ -396,7 +353,6 @@ describe("Sync Logs Repository", () => {
 				await createSyncLog({
 					project_id: project.id,
 					sync_type: SYNC_TYPES.PROJECTS,
-					completed_at: new Date(),
 				});
 
 				const newProjectsCount = await syncLogsRepository.count({

--- a/src/database/repositories/__tests__/sync-logs.test.ts
+++ b/src/database/repositories/__tests__/sync-logs.test.ts
@@ -242,15 +242,29 @@ describe("Sync Logs Repository", () => {
 				// テスト用プロジェクトを作成
 				const project = await createProject();
 
-				// 複数の同期ログを作成し、配列で保存
-				const createdLogs = await createSyncLogs(3, { project_id: project.id });
+				// created_atをずらしながら3つの同期ログを作成
+				const baseDate = new Date();
+				const createdLogs = await Promise.all([
+					createSyncLog({
+						project_id: project.id,
+						created_at: new Date(baseDate.getTime()),
+					}),
+					createSyncLog({
+						project_id: project.id,
+						created_at: new Date(baseDate.getTime() + 10),
+					}),
+					createSyncLog({
+						project_id: project.id,
+						created_at: new Date(baseDate.getTime() + 20),
+					}),
+				]);
 
 				const latest = await syncLogsRepository.findLatest(project.id);
 
 				expect(latest).toBeDefined();
 				expect(latest?.project_id).toBe(project.id);
 
-				// 最後に作成されたログと比較
+				// 最後に作成されたログ（最新のcreated_at）と比較
 				expect(latest?.id).toBe(createdLogs[2].id);
 			});
 		});

--- a/src/database/repositories/sync-logs.ts
+++ b/src/database/repositories/sync-logs.ts
@@ -46,7 +46,7 @@ export class SyncLogsRepository {
 	/**
 	 * 条件に基づいて同期ログを検索（ページネーション対応）
 	 * @param params 検索条件
-	 * @returns 同期ログ配列（開始日時降順でソート）
+	 * @returns 同期ログ配列（作成日時降順でソート）
 	 */
 	async find(params: FindSyncLogsParams = {}): Promise<SyncLog[]> {
 		const db = await getDb();
@@ -67,14 +67,14 @@ export class SyncLogsRepository {
 				.select()
 				.from(syncLogs)
 				.where(and(...conditions))
-				.orderBy(desc(syncLogs.completed_at))
+				.orderBy(desc(syncLogs.created_at))
 				.limit(limit)
 				.offset(offset);
 		} else {
 			return await db
 				.select()
 				.from(syncLogs)
-				.orderBy(desc(syncLogs.completed_at))
+				.orderBy(desc(syncLogs.created_at))
 				.limit(limit)
 				.offset(offset);
 		}

--- a/src/database/schema/sync-logs.ts
+++ b/src/database/schema/sync-logs.ts
@@ -31,15 +31,6 @@ export const syncLogs = pgTable(
 		// 同期タイプ（必須）
 		sync_type: syncTypeEnum("sync_type").notNull(),
 
-		// 同期完了日時（必須）
-		completed_at: timestamp("completed_at").notNull(),
-
-		// 処理レコード数（必須）
-		records_processed: integer("records_processed").notNull(),
-
-		// 追加レコード数（必須）
-		records_added: integer("records_added").notNull(),
-
 		// 最後に処理したアイテムの日時（必須、コミット・MR同期時に使用）
 		last_item_date: timestamp("last_item_date").notNull(),
 
@@ -47,10 +38,12 @@ export const syncLogs = pgTable(
 		created_at: timestamp("created_at").defaultNow().notNull(),
 	},
 	(table) => ({
-		// プロジェクト + タイプ + 完了日時での検索・ソート用複合インデックス
-		project_type_completed_idx: index(
-			"sync_logs_project_type_completed_idx",
-		).on(table.project_id, table.sync_type, table.completed_at),
+		// プロジェクト + タイプ + 作成日時での検索・ソート用複合インデックス
+		project_type_created_idx: index("sync_logs_project_type_created_idx").on(
+			table.project_id,
+			table.sync_type,
+			table.created_at,
+		),
 	}),
 );
 

--- a/src/database/testing/factories/sync-logs.ts
+++ b/src/database/testing/factories/sync-logs.ts
@@ -26,9 +26,6 @@ export function buildNewSyncLog(
 	return {
 		project_id: 1, // デフォルトプロジェクトID
 		sync_type: SYNC_TYPES.PROJECTS,
-		completed_at: new Date("2023-01-01T10:30:00Z"),
-		records_processed: 10,
-		records_added: 5,
 		last_item_date: new Date("2023-01-01T09:00:00Z"),
 		...overrides,
 	};
@@ -48,12 +45,6 @@ export function buildSyncLog(overrides: Partial<SyncLog> = {}): SyncLog {
 		newSyncLogOverrides.project_id = overrides.project_id;
 	if (overrides.sync_type !== undefined)
 		newSyncLogOverrides.sync_type = overrides.sync_type;
-	if (overrides.completed_at !== undefined)
-		newSyncLogOverrides.completed_at = overrides.completed_at;
-	if (overrides.records_processed !== undefined)
-		newSyncLogOverrides.records_processed = overrides.records_processed;
-	if (overrides.records_added !== undefined)
-		newSyncLogOverrides.records_added = overrides.records_added;
 	if (overrides.last_item_date !== undefined)
 		newSyncLogOverrides.last_item_date = overrides.last_item_date;
 
@@ -69,9 +60,6 @@ export function buildSyncLog(overrides: Partial<SyncLog> = {}): SyncLog {
 	// undefinedをデフォルト値に変換して型制約を満たす
 	return {
 		...result,
-		completed_at: result.completed_at ?? new Date("2023-01-01T10:30:00Z"),
-		records_processed: result.records_processed ?? 10,
-		records_added: result.records_added ?? 5,
 		last_item_date: result.last_item_date ?? new Date("2023-01-01T09:00:00Z"),
 	};
 }


### PR DESCRIPTION
## 概要

sync_logsテーブルから以下の不要なカラムを削除しました：
- `completed_at`: `created_at`と重複する情報
- `records_processed`: 統計情報として不要
- `records_added`: 統計情報として不要

## 主な変更内容

### データベーススキーマ
- 3つのカラムを削除するマイグレーション（0006）を追加
- インデックスを`completed_at`ベースから`created_at`ベースに変更

### コード修正
- リポジトリクラスのソート順序を`created_at`降順に変更
- テストファクトリから削除されたフィールドの参照を除去
- テストケースを削除されたフィールドに合わせて修正

### コードの最適化
- 引数が`project_id`のみの場合を1行にコンパクト化

## テスト計画

- [x] 既存のテストがすべて通ること
- [x] マイグレーションが正常に実行されること
- [x] 型チェックとリントが通ること

🤖 Generated with [Claude Code](https://claude.ai/code)