### PR TITLE
commitsテーブルのauthor_dateカラムをauthored_dateに変更

### DIFF
--- a/src/database/migrations/0007_parallel_talos.sql
+++ b/src/database/migrations/0007_parallel_talos.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "commits" RENAME COLUMN "author_date" TO "authored_date";--> statement-breakpoint
+DROP INDEX "commits_author_date_idx";--> statement-breakpoint
+CREATE INDEX "commits_authored_date_idx" ON "commits" USING btree ("authored_date");

--- a/src/database/migrations/meta/0007_snapshot.json
+++ b/src/database/migrations/meta/0007_snapshot.json
@@ -1,0 +1,369 @@
+{
+  "id": "095f36b4-0c34-40dd-8601-07e376cc5371",
+  "prevId": "9086c3d0-3c59-4798-b9b7-00f5f9eefba3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.commits": {
+      "name": "commits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha": {
+          "name": "sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_email": {
+          "name": "author_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authored_date": {
+          "name": "authored_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "additions": {
+          "name": "additions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletions": {
+          "name": "deletions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "commits_project_sha_unique": {
+          "name": "commits_project_sha_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "commits_project_id_idx": {
+          "name": "commits_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "commits_author_email_idx": {
+          "name": "commits_author_email_idx",
+          "columns": [
+            {
+              "expression": "author_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "commits_authored_date_idx": {
+          "name": "commits_authored_date_idx",
+          "columns": [
+            {
+              "expression": "authored_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "commits_project_id_projects_id_fk": {
+          "name": "commits_project_id_projects_id_fk",
+          "tableFrom": "commits",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "gitlab_id": {
+          "name": "gitlab_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "web_url": {
+          "name": "web_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "gitlab_created_at": {
+          "name": "gitlab_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "projects_gitlab_id_unique": {
+          "name": "projects_gitlab_id_unique",
+          "columns": [
+            {
+              "expression": "gitlab_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_name_idx": {
+          "name": "projects_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_logs": {
+      "name": "sync_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_type": {
+          "name": "sync_type",
+          "type": "sync_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_item_date": {
+          "name": "last_item_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sync_logs_project_type_created_idx": {
+          "name": "sync_logs_project_type_created_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sync_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sync_logs_project_id_projects_id_fk": {
+          "name": "sync_logs_project_id_projects_id_fk",
+          "tableFrom": "sync_logs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.sync_type": {
+      "name": "sync_type",
+      "schema": "public",
+      "values": [
+        "projects",
+        "commits"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/database/migrations/meta/_journal.json
+++ b/src/database/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1754245799489,
       "tag": "0006_real_ghost_rider",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1754676585652,
+      "tag": "0007_parallel_talos",
+      "breakpoints": true
     }
   ]
 }

--- a/src/database/repositories/__tests__/commits.test.ts
+++ b/src/database/repositories/__tests__/commits.test.ts
@@ -28,7 +28,7 @@ describe("Commits Repository", () => {
 				expect(commit.message).toBe(testCommit.message);
 				expect(commit.author_name).toBe(testCommit.author_name);
 				expect(commit.author_email).toBe(testCommit.author_email);
-				expect(commit.author_date).toEqual(testCommit.author_date);
+				expect(commit.authored_date).toEqual(testCommit.authored_date);
 				expect(commit.additions).toBe(testCommit.additions);
 				expect(commit.deletions).toBe(testCommit.deletions);
 				expect(commit.created_at).toBeDefined();
@@ -164,9 +164,9 @@ describe("Commits Repository", () => {
 				expect(Array.isArray(commits)).toBe(true);
 				expect(commits.length).toBeGreaterThanOrEqual(5);
 
-				// author_date降順でソートされているかチェック
+				// authored_date降順でソートされているかチェック
 				for (let i = 1; i < commits.length; i++) {
-					expect(commits[i].author_date <= commits[i - 1].author_date).toBe(
+					expect(commits[i].authored_date <= commits[i - 1].authored_date).toBe(
 						true,
 					);
 				}

--- a/src/database/repositories/commits.ts
+++ b/src/database/repositories/commits.ts
@@ -87,7 +87,7 @@ export class CommitsRepository {
 			.select()
 			.from(commits)
 			.where(eq(commits.project_id, projectId))
-			.orderBy(desc(commits.author_date))
+			.orderBy(desc(commits.authored_date))
 			.limit(limit)
 			.offset(offset);
 	}
@@ -107,7 +107,7 @@ export class CommitsRepository {
 			.select()
 			.from(commits)
 			.where(inArray(commits.sha, shas))
-			.orderBy(desc(commits.author_date));
+			.orderBy(desc(commits.authored_date));
 	}
 
 	/**

--- a/src/database/schema/commits.ts
+++ b/src/database/schema/commits.ts
@@ -38,7 +38,7 @@ export const commits = pgTable(
 		author_email: varchar("author_email", { length: 255 }).notNull(),
 
 		// 作者日時（GitLab上での authored_date）
-		author_date: timestamp("author_date").notNull(),
+		authored_date: timestamp("authored_date").notNull(),
 
 		// 追加行数（任意）
 		additions: integer("additions"),
@@ -63,7 +63,9 @@ export const commits = pgTable(
 		author_email_idx: index("commits_author_email_idx").on(table.author_email),
 
 		// 日付での検索用インデックス
-		author_date_idx: index("commits_author_date_idx").on(table.author_date),
+		authored_date_idx: index("commits_authored_date_idx").on(
+			table.authored_date,
+		),
 	}),
 );
 

--- a/src/lib/testing/factories/database/commits.ts
+++ b/src/lib/testing/factories/database/commits.ts
@@ -27,7 +27,7 @@ export function buildNewCommit(overrides: Partial<NewCommit> = {}): NewCommit {
 		message: `テストコミット ${uniqueId}`,
 		author_name: "テストユーザー",
 		author_email: "test@example.com",
-		author_date: new Date("2023-01-01T10:00:00Z"),
+		authored_date: new Date("2023-01-01T10:00:00Z"),
 		additions: 10,
 		deletions: 5,
 		...overrides,
@@ -53,8 +53,8 @@ export function buildCommit(overrides: Partial<Commit> = {}): Commit {
 		newCommitOverrides.author_name = overrides.author_name;
 	if (overrides.author_email !== undefined)
 		newCommitOverrides.author_email = overrides.author_email;
-	if (overrides.author_date !== undefined)
-		newCommitOverrides.author_date = overrides.author_date;
+	if (overrides.authored_date !== undefined)
+		newCommitOverrides.authored_date = overrides.authored_date;
 	if (overrides.additions !== undefined)
 		newCommitOverrides.additions = overrides.additions;
 	if (overrides.deletions !== undefined)

--- a/src/services/sync-commits.ts
+++ b/src/services/sync-commits.ts
@@ -103,7 +103,7 @@ export class SyncCommitsService {
 			// 最新のコミット日時を更新
 			lastItemDate = commits.reduce(
 				(latest, commit) =>
-					commit.author_date > latest ? commit.author_date : latest,
+					commit.authored_date > latest ? commit.authored_date : latest,
 				lastItemDate,
 			);
 
@@ -179,7 +179,7 @@ export class SyncCommitsService {
 			message: gitlabCommit.message,
 			author_name: gitlabCommit.author_name,
 			author_email: gitlabCommit.author_email,
-			author_date: new Date(gitlabCommit.authored_date),
+			authored_date: new Date(gitlabCommit.authored_date),
 			additions: gitlabCommit.stats?.additions ?? null,
 			deletions: gitlabCommit.stats?.deletions ?? null,
 		};


### PR DESCRIPTION
## 概要
GitLab APIの応答フィールド名との整合性を保つため、commitsテーブルのauthor_dateカラム名をauthored_dateに変更しました。

## 変更内容
- データベーススキーマの更新
- マイグレーションファイルの生成  
- 関連するリポジトリ、サービス、テストの更新
- インデックス名も合わせて更新

## テスト
- [x] ローカルでの動作確認
- [x] 品質チェック通過（lint, format, typecheck）
- [x] テスト通過（全180テストが成功）

🤖 Generated with [Claude Code](https://claude.ai/code)