### PR TITLE
不要な@types/postcss-load-configパッケージを削除

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,6 @@
 				"@testing-library/react": "^16.3.0",
 				"@testing-library/user-event": "^14.6.1",
 				"@types/node": "^22.16.3",
-				"@types/postcss-load-config": "^3.0.1",
 				"@types/react": "^19.1.8",
 				"@types/react-dom": "^19.1.7",
 				"autoprefixer": "^10.4.21",
@@ -2955,17 +2954,6 @@
 				"pg-types": "^2.2.0"
 			}
 		},
-		"node_modules/@types/postcss-load-config": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/@types/postcss-load-config/-/postcss-load-config-3.0.1.tgz",
-			"integrity": "sha512-W/F7myqejNGhK9mkm1u0rZeS4wzRFTwo0ifUv1XKokYN67oRyTucH6R1ttdL95bXD1UJKD/zq5QNlg3vYgfjDg==",
-			"deprecated": "This is a stub types definition. postcss-load-config provides its own type definitions, so you do not need this installed.",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"postcss-load-config": "*"
-			}
-		},
 		"node_modules/@types/react": {
 			"version": "19.1.9",
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.9.tgz",
@@ -5376,49 +5364,6 @@
 			},
 			"engines": {
 				"node": "^10 || ^12 || >=14"
-			}
-		},
-		"node_modules/postcss-load-config": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
-			"integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/postcss/"
-				},
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/ai"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"lilconfig": "^3.1.1"
-			},
-			"engines": {
-				"node": ">= 18"
-			},
-			"peerDependencies": {
-				"jiti": ">=1.21.0",
-				"postcss": ">=8.0.9",
-				"tsx": "^4.8.1",
-				"yaml": "^2.4.2"
-			},
-			"peerDependenciesMeta": {
-				"jiti": {
-					"optional": true
-				},
-				"postcss": {
-					"optional": true
-				},
-				"tsx": {
-					"optional": true
-				},
-				"yaml": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/postcss-value-parser": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
 		"@testing-library/react": "^16.3.0",
 		"@testing-library/user-event": "^14.6.1",
 		"@types/node": "^22.16.3",
-		"@types/postcss-load-config": "^3.0.1",
 		"@types/react": "^19.1.8",
 		"@types/react-dom": "^19.1.7",
 		"autoprefixer": "^10.4.21",


### PR DESCRIPTION
## 概要
npm ciで表示されていたdeprecated警告を解消するため、不要な型定義パッケージを削除しました。

## 変更内容
- `@types/postcss-load-config`パッケージを削除
  - postcss-load-configが自身の型定義を提供するため不要

## テスト
- [x] npm ciで警告が減少したことを確認
- [x] 型チェック通過（npm run typecheck）
- [x] リンター通過（npm run lint）
- [x] テスト通過（npm test）

🤖 Generated with [Claude Code](https://claude.ai/code)