### PR TITLE
Grammarlyブラウザ拡張機能によるhydrationエラーを修正

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,7 +19,7 @@ export default function RootLayout({
 }) {
 	return (
 		<html lang="ja">
-			<body>
+			<body suppressHydrationWarning>
 				<GlobalNav />
 				<main>{children}</main>
 			</body>


### PR DESCRIPTION
## 概要
Next.jsアプリケーションで発生していたhydrationエラーを修正しました。

## 問題
Grammarlyなどのブラウザ拡張機能が`body`タグに属性を自動追加することで、サーバーサイドレンダリングされたHTMLとクライアント側のHTMLが不一致となり、hydrationエラーが発生していました。

## 解決策
`body`タグに`suppressHydrationWarning`属性を追加し、ブラウザ拡張機能によるDOM変更を許容するようにしました。

## テスト
- [x] ローカルでの動作確認
- [x] 品質チェック通過（lint, typecheck）
- [x] テスト通過

🤖 Generated with [Claude Code](https://claude.ai/code)