### PR TITLE
コミッターランキング機能を追加

### DIFF
--- a/src/app/projects/[id]/__tests__/page.test.tsx
+++ b/src/app/projects/[id]/__tests__/page.test.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import { buildProjectWithStats } from "@/lib/testing/factories";
 import {
+	getCommitterRanking,
 	getMonthlyCommitStats,
 	getProjectDetail,
 	getWeeklyCommitStats,
@@ -29,6 +30,7 @@ vi.mock("../../actions", () => ({
 	getProjectDetail: vi.fn(),
 	getMonthlyCommitStats: vi.fn(),
 	getWeeklyCommitStats: vi.fn(),
+	getCommitterRanking: vi.fn(),
 }));
 
 const mockProject = buildProjectWithStats({
@@ -53,6 +55,15 @@ const mockWeeklyData = [
 	{ period: "2024-02", count: 5, type: "weekly" as const },
 ];
 
+const mockCommitterRanking = [
+	{
+		rank: 1,
+		authorName: "Test User",
+		authorEmail: "test@example.com",
+		commitCount: 10,
+	},
+];
+
 describe("ProjectDetailPage", () => {
 	it("should display loading state initially", () => {
 		vi.mocked(getProjectDetail).mockImplementation(
@@ -62,6 +73,9 @@ describe("ProjectDetailPage", () => {
 			() => new Promise(() => {}),
 		);
 		vi.mocked(getWeeklyCommitStats).mockImplementation(
+			() => new Promise(() => {}),
+		);
+		vi.mocked(getCommitterRanking).mockImplementation(
 			() => new Promise(() => {}),
 		);
 
@@ -77,6 +91,7 @@ describe("ProjectDetailPage", () => {
 		vi.mocked(getProjectDetail).mockResolvedValue(mockProject);
 		vi.mocked(getMonthlyCommitStats).mockResolvedValue(mockMonthlyData);
 		vi.mocked(getWeeklyCommitStats).mockResolvedValue(mockWeeklyData);
+		vi.mocked(getCommitterRanking).mockResolvedValue(mockCommitterRanking);
 
 		render(<ProjectDetailPage params={{ id: "1" }} />);
 
@@ -115,6 +130,7 @@ describe("ProjectDetailPage", () => {
 		);
 		vi.mocked(getMonthlyCommitStats).mockResolvedValue([]);
 		vi.mocked(getWeeklyCommitStats).mockResolvedValue(mockWeeklyData);
+		vi.mocked(getCommitterRanking).mockResolvedValue([]);
 
 		render(<ProjectDetailPage params={{ id: "1" }} />);
 
@@ -131,6 +147,7 @@ describe("ProjectDetailPage", () => {
 		vi.mocked(getProjectDetail).mockResolvedValue(null);
 		vi.mocked(getMonthlyCommitStats).mockResolvedValue([]);
 		vi.mocked(getWeeklyCommitStats).mockResolvedValue(mockWeeklyData);
+		vi.mocked(getCommitterRanking).mockResolvedValue([]);
 
 		render(<ProjectDetailPage params={{ id: "1" }} />);
 
@@ -153,6 +170,7 @@ describe("ProjectDetailPage", () => {
 		vi.mocked(getProjectDetail).mockResolvedValue(projectWithoutSync);
 		vi.mocked(getMonthlyCommitStats).mockResolvedValue([]);
 		vi.mocked(getWeeklyCommitStats).mockResolvedValue(mockWeeklyData);
+		vi.mocked(getCommitterRanking).mockResolvedValue(mockCommitterRanking);
 
 		render(<ProjectDetailPage params={{ id: "1" }} />);
 

--- a/src/app/projects/actions.ts
+++ b/src/app/projects/actions.ts
@@ -5,7 +5,9 @@ import { redirect } from "next/navigation";
 import { z } from "zod";
 import { commitsRepository, projectsRepository } from "@/database/index";
 import type {
+	CommitterRanking,
 	MonthlyCommitStats,
+	RankingPeriod,
 	WeeklyCommitStats,
 } from "@/database/repositories/commits";
 import type { ProjectWithStats } from "@/database/schema/projects";
@@ -71,6 +73,24 @@ export async function getWeeklyCommitStats(
 	} catch (error) {
 		console.error("週別コミット統計の取得に失敗しました:", error);
 		throw new Error("週別コミット統計の取得に失敗しました");
+	}
+}
+
+/**
+ * プロジェクトのコミッターランキングを取得するServer Action
+ * @param projectId プロジェクトID
+ * @param period 期間（all: 全期間, year: 1年, halfYear: 半年, month: 1ヶ月）
+ * @returns コミッターランキングの配列
+ */
+export async function getCommitterRanking(
+	projectId: number,
+	period: RankingPeriod = "all",
+): Promise<CommitterRanking[]> {
+	try {
+		return await commitsRepository.getCommitterRanking(projectId, period, 10);
+	} catch (error) {
+		console.error("コミッターランキングの取得に失敗しました:", error);
+		throw new Error("コミッターランキングの取得に失敗しました");
 	}
 }
 

--- a/src/components/commits/__tests__/committer-ranking-card.test.tsx
+++ b/src/components/commits/__tests__/committer-ranking-card.test.tsx
@@ -1,0 +1,205 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type {
+	CommitterRanking,
+	RankingPeriod,
+} from "@/database/repositories/commits";
+import { CommitterRankingCard } from "../committer-ranking-card";
+
+describe("CommitterRankingCard", () => {
+	afterEach(() => {
+		cleanup();
+	});
+
+	const mockRankings: Record<RankingPeriod, CommitterRanking[]> = {
+		all: [
+			{
+				rank: 1,
+				authorName: "Alice",
+				authorEmail: "alice@example.com",
+				commitCount: 150,
+			},
+			{
+				rank: 2,
+				authorName: "Bob",
+				authorEmail: "bob@example.com",
+				commitCount: 120,
+			},
+			{
+				rank: 3,
+				authorName: "Charlie",
+				authorEmail: "charlie@example.com",
+				commitCount: 95,
+			},
+		],
+		year: [
+			{
+				rank: 1,
+				authorName: "Bob",
+				authorEmail: "bob@example.com",
+				commitCount: 80,
+			},
+			{
+				rank: 2,
+				authorName: "Alice",
+				authorEmail: "alice@example.com",
+				commitCount: 60,
+			},
+		],
+		halfYear: [
+			{
+				rank: 1,
+				authorName: "Charlie",
+				authorEmail: "charlie@example.com",
+				commitCount: 45,
+			},
+		],
+		month: [],
+	};
+
+	it("コンポーネントが正しくレンダリングされる", () => {
+		render(<CommitterRankingCard rankings={mockRankings} />);
+
+		expect(screen.getByText("コミッターランキング")).toBeInTheDocument();
+		expect(screen.getByText("全期間")).toBeInTheDocument();
+		expect(screen.getByText("直近1年")).toBeInTheDocument();
+		expect(screen.getByText("直近半年")).toBeInTheDocument();
+		expect(screen.getByText("直近1ヶ月")).toBeInTheDocument();
+	});
+
+	it("デフォルトで全期間のランキングが表示される", () => {
+		render(<CommitterRankingCard rankings={mockRankings} />);
+
+		// 名前が表示されていることを確認
+		expect(screen.getByText("Alice")).toBeInTheDocument();
+		expect(screen.getByText("Bob")).toBeInTheDocument();
+		expect(screen.getByText("Charlie")).toBeInTheDocument();
+
+		// メールアドレスが表示されていることを確認
+		expect(screen.getByText("alice@example.com")).toBeInTheDocument();
+		expect(screen.getByText("bob@example.com")).toBeInTheDocument();
+		expect(screen.getByText("charlie@example.com")).toBeInTheDocument();
+
+		// コミット数が表示されていることを確認
+		expect(screen.getByText("150")).toBeInTheDocument();
+		expect(screen.getByText("120")).toBeInTheDocument();
+		expect(screen.getByText("95")).toBeInTheDocument();
+	});
+
+	it("上位3名にメダルアイコンが表示される", () => {
+		const { container } = render(
+			<CommitterRankingCard rankings={mockRankings} />,
+		);
+
+		// ランクアイコンを含む要素を取得
+		const rankElements = container.querySelectorAll(
+			".flex.items-center.justify-center.w-8.h-8",
+		);
+		const rankTexts = Array.from(rankElements).map((el) => el.textContent);
+
+		// 上位3名にメダルが表示されることを確認
+		expect(rankTexts[0]).toBe("🥇");
+		expect(rankTexts[1]).toBe("🥈");
+		expect(rankTexts[2]).toBe("🥉");
+	});
+
+	it("期間を切り替えるとランキングが更新される", async () => {
+		const user = userEvent.setup();
+		render(<CommitterRankingCard rankings={mockRankings} />);
+
+		// 直近1年をクリック
+		await user.click(screen.getByText("直近1年"));
+
+		// 直近1年のランキングが表示される
+		expect(screen.getByText("Bob")).toBeInTheDocument();
+		expect(screen.getByText("80")).toBeInTheDocument();
+		expect(screen.getByText("Alice")).toBeInTheDocument();
+		expect(screen.getByText("60")).toBeInTheDocument();
+
+		// Charlie（全期間では3位）は表示されない
+		expect(screen.queryByText("Charlie")).not.toBeInTheDocument();
+	});
+
+	it("期間変更時にコールバックが呼ばれる", async () => {
+		const user = userEvent.setup();
+		const onPeriodChange = vi.fn();
+		render(
+			<CommitterRankingCard
+				rankings={mockRankings}
+				onPeriodChange={onPeriodChange}
+			/>,
+		);
+
+		await user.click(screen.getByText("直近半年"));
+
+		expect(onPeriodChange).toHaveBeenCalledWith("halfYear");
+	});
+
+	it("データがない期間は空メッセージを表示する", async () => {
+		const user = userEvent.setup();
+		render(<CommitterRankingCard rankings={mockRankings} />);
+
+		await user.click(screen.getByText("直近1ヶ月"));
+
+		expect(
+			screen.getByText("この期間のコミットデータがありません"),
+		).toBeInTheDocument();
+	});
+
+	it("選択された期間のボタンがハイライトされる", async () => {
+		const user = userEvent.setup();
+		render(<CommitterRankingCard rankings={mockRankings} />);
+
+		// 初期状態で全期間がハイライト
+		const allButton = screen.getByText("全期間");
+		expect(allButton.className).toContain("bg-primary");
+
+		// 直近1年をクリック
+		await user.click(screen.getByText("直近1年"));
+
+		// 直近1年がハイライト、全期間はハイライト解除
+		const yearButton = screen.getByText("直近1年");
+		expect(yearButton.className).toContain("bg-primary");
+		expect(allButton.className).not.toContain("bg-primary");
+	});
+
+	it("ランキング番号が正しく表示される", () => {
+		const longRankings: Record<RankingPeriod, CommitterRanking[]> = {
+			all: Array.from({ length: 10 }, (_, i) => ({
+				rank: i + 1,
+				authorName: `User ${i + 1}`,
+				authorEmail: `user${i + 1}@example.com`,
+				commitCount: 100 - i * 10,
+			})),
+			year: [],
+			halfYear: [],
+			month: [],
+		};
+
+		const { container } = render(
+			<CommitterRankingCard rankings={longRankings} />,
+		);
+
+		// 4位以降は数字で表示される
+		const rankElements = container.querySelectorAll(
+			".flex.items-center.justify-center.w-8.h-8",
+		);
+		const rankTexts = Array.from(rankElements).map((el) => el.textContent);
+
+		expect(rankTexts).toContain("🥇"); // 1位
+		expect(rankTexts).toContain("🥈"); // 2位
+		expect(rankTexts).toContain("🥉"); // 3位
+		expect(rankTexts).toContain("4"); // 4位
+		expect(rankTexts).toContain("10"); // 10位
+	});
+
+	it("コミット数のラベルが正しく表示される", () => {
+		render(<CommitterRankingCard rankings={mockRankings} />);
+
+		// コミットカウントが表示されていることを確認
+		expect(screen.getByText("150")).toBeInTheDocument();
+		expect(screen.getByText("120")).toBeInTheDocument();
+		expect(screen.getByText("95")).toBeInTheDocument();
+	});
+});

--- a/src/components/commits/committer-ranking-card.tsx
+++ b/src/components/commits/committer-ranking-card.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { Trophy, User } from "lucide-react";
+import { useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type {
+	CommitterRanking,
+	RankingPeriod,
+} from "@/database/repositories/commits";
+
+interface CommitterRankingCardProps {
+	rankings: Record<RankingPeriod, CommitterRanking[]>;
+	onPeriodChange?: (period: RankingPeriod) => void;
+}
+
+const periodLabels: Record<RankingPeriod, string> = {
+	all: "全期間",
+	year: "直近1年",
+	halfYear: "直近半年",
+	month: "直近1ヶ月",
+};
+
+const getRankIcon = (rank: number) => {
+	switch (rank) {
+		case 1:
+			return "🥇";
+		case 2:
+			return "🥈";
+		case 3:
+			return "🥉";
+		default:
+			return null;
+	}
+};
+
+export function CommitterRankingCard({
+	rankings,
+	onPeriodChange,
+}: CommitterRankingCardProps) {
+	const [selectedPeriod, setSelectedPeriod] = useState<RankingPeriod>("all");
+
+	const handlePeriodChange = (period: RankingPeriod) => {
+		setSelectedPeriod(period);
+		onPeriodChange?.(period);
+	};
+
+	const currentRankings = rankings[selectedPeriod] || [];
+
+	return (
+		<Card>
+			<CardHeader>
+				<div className="flex items-center justify-between">
+					<CardTitle className="flex items-center gap-2">
+						<Trophy className="h-5 w-5" />
+						コミッターランキング
+					</CardTitle>
+				</div>
+				<div className="flex gap-2 mt-4">
+					{(Object.keys(periodLabels) as RankingPeriod[]).map((period) => (
+						<button
+							key={period}
+							type="button"
+							onClick={() => handlePeriodChange(period)}
+							className={`px-3 py-1 text-sm rounded-md transition-colors ${
+								selectedPeriod === period
+									? "bg-primary text-primary-foreground"
+									: "bg-muted hover:bg-muted/80"
+							}`}
+						>
+							{periodLabels[period]}
+						</button>
+					))}
+				</div>
+			</CardHeader>
+			<CardContent>
+				{currentRankings.length === 0 ? (
+					<p className="text-center text-muted-foreground py-8">
+						この期間のコミットデータがありません
+					</p>
+				) : (
+					<div className="space-y-3">
+						{currentRankings.map((ranking) => (
+							<div
+								key={`${ranking.authorEmail}-${ranking.rank}`}
+								className="flex items-center justify-between p-3 rounded-lg border hover:bg-muted/50 transition-colors"
+							>
+								<div className="flex items-center gap-3">
+									<div className="flex items-center justify-center w-8 h-8">
+										{getRankIcon(ranking.rank) || (
+											<span className="text-sm font-semibold text-muted-foreground">
+												{ranking.rank}
+											</span>
+										)}
+									</div>
+									<div className="flex items-center gap-2">
+										<User className="h-4 w-4 text-muted-foreground" />
+										<div>
+											<div className="font-medium">{ranking.authorName}</div>
+											<div className="text-xs text-muted-foreground">
+												{ranking.authorEmail}
+											</div>
+										</div>
+									</div>
+								</div>
+								<div className="text-right">
+									<div className="font-semibold">{ranking.commitCount}</div>
+									<div className="text-xs text-muted-foreground">コミット</div>
+								</div>
+							</div>
+						))}
+					</div>
+				)}
+			</CardContent>
+		</Card>
+	);
+}

--- a/src/database/repositories/__tests__/committer-ranking.test.ts
+++ b/src/database/repositories/__tests__/committer-ranking.test.ts
@@ -1,0 +1,353 @@
+import { describe, expect, it } from "vitest";
+import { commitsRepository, projectsRepository } from "@/database/index";
+import { buildNewCommit, buildNewProject } from "@/lib/testing/factories";
+import { withTransaction } from "@/lib/testing/transaction";
+
+describe("CommitsRepository - getCommitterRanking", () => {
+	it("全期間のコミッターランキングを取得できる", async () => {
+		await withTransaction(async () => {
+			// テスト用プロジェクトを作成
+			const project = await projectsRepository.create(
+				buildNewProject({
+					name: "Test Project",
+				}),
+			);
+
+			// 異なる作者のコミットを作成
+			const now = new Date();
+
+			// ユーザー1: 5コミット
+			for (let i = 0; i < 5; i++) {
+				await commitsRepository.create(
+					buildNewCommit({
+						project_id: project.id,
+						sha: `user1-commit-${i}`,
+						author_name: "User One",
+						author_email: "user1@example.com",
+						authored_date: new Date(now.getTime() - i * 24 * 60 * 60 * 1000),
+					}),
+				);
+			}
+
+			// ユーザー2: 3コミット
+			for (let i = 0; i < 3; i++) {
+				await commitsRepository.create(
+					buildNewCommit({
+						project_id: project.id,
+						sha: `user2-commit-${i}`,
+						author_name: "User Two",
+						author_email: "user2@example.com",
+						authored_date: new Date(now.getTime() - i * 24 * 60 * 60 * 1000),
+					}),
+				);
+			}
+
+			// ユーザー3: 1コミット
+			await commitsRepository.create(
+				buildNewCommit({
+					project_id: project.id,
+					sha: "user3-commit-1",
+					author_name: "User Three",
+					author_email: "user3@example.com",
+					authored_date: now,
+				}),
+			);
+
+			// ランキングを取得
+			const rankings = await commitsRepository.getCommitterRanking(
+				project.id,
+				"all",
+			);
+
+			// 検証
+			expect(rankings).toHaveLength(3);
+			expect(rankings[0]).toEqual({
+				rank: 1,
+				authorName: "User One",
+				authorEmail: "user1@example.com",
+				commitCount: 5,
+			});
+			expect(rankings[1]).toEqual({
+				rank: 2,
+				authorName: "User Two",
+				authorEmail: "user2@example.com",
+				commitCount: 3,
+			});
+			expect(rankings[2]).toEqual({
+				rank: 3,
+				authorName: "User Three",
+				authorEmail: "user3@example.com",
+				commitCount: 1,
+			});
+		});
+	});
+
+	it("直近1年のコミッターランキングを取得できる", async () => {
+		await withTransaction(async () => {
+			// テスト用プロジェクトを作成
+			const project = await projectsRepository.create(
+				buildNewProject({
+					name: "Test Project",
+				}),
+			);
+
+			const now = new Date();
+			const twoYearsAgo = new Date(now);
+			twoYearsAgo.setFullYear(now.getFullYear() - 2);
+			const sixMonthsAgo = new Date(now);
+			sixMonthsAgo.setMonth(now.getMonth() - 6);
+
+			// 2年前のコミット（ランキングに含まれない）
+			await commitsRepository.create(
+				buildNewCommit({
+					project_id: project.id,
+					sha: "old-commit",
+					author_name: "Old User",
+					author_email: "old@example.com",
+					authored_date: twoYearsAgo,
+				}),
+			);
+
+			// 6ヶ月前のコミット（ランキングに含まれる）
+			await commitsRepository.create(
+				buildNewCommit({
+					project_id: project.id,
+					sha: "recent-commit-1",
+					author_name: "Recent User",
+					author_email: "recent@example.com",
+					authored_date: sixMonthsAgo,
+				}),
+			);
+
+			// 最近のコミット（ランキングに含まれる）
+			await commitsRepository.create(
+				buildNewCommit({
+					project_id: project.id,
+					sha: "recent-commit-2",
+					author_name: "Recent User",
+					author_email: "recent@example.com",
+					authored_date: now,
+				}),
+			);
+
+			// 1年のランキングを取得
+			const rankings = await commitsRepository.getCommitterRanking(
+				project.id,
+				"year",
+			);
+
+			// 検証：古いコミットは含まれない
+			expect(rankings).toHaveLength(1);
+			expect(rankings[0]).toEqual({
+				rank: 1,
+				authorName: "Recent User",
+				authorEmail: "recent@example.com",
+				commitCount: 2,
+			});
+		});
+	});
+
+	it("直近半年のコミッターランキングを取得できる", async () => {
+		await withTransaction(async () => {
+			// テスト用プロジェクトを作成
+			const project = await projectsRepository.create(
+				buildNewProject({
+					name: "Test Project",
+				}),
+			);
+
+			const now = new Date();
+			const eightMonthsAgo = new Date(now);
+			eightMonthsAgo.setMonth(now.getMonth() - 8);
+			const threeMonthsAgo = new Date(now);
+			threeMonthsAgo.setMonth(now.getMonth() - 3);
+
+			// 8ヶ月前のコミット（ランキングに含まれない）
+			await commitsRepository.create(
+				buildNewCommit({
+					project_id: project.id,
+					sha: "old-commit",
+					author_name: "Old User",
+					author_email: "old@example.com",
+					authored_date: eightMonthsAgo,
+				}),
+			);
+
+			// 3ヶ月前のコミット（ランキングに含まれる）
+			for (let i = 0; i < 2; i++) {
+				await commitsRepository.create(
+					buildNewCommit({
+						project_id: project.id,
+						sha: `recent-commit-${i}`,
+						author_name: "Recent User",
+						author_email: "recent@example.com",
+						authored_date: threeMonthsAgo,
+					}),
+				);
+			}
+
+			// 半年のランキングを取得
+			const rankings = await commitsRepository.getCommitterRanking(
+				project.id,
+				"halfYear",
+			);
+
+			// 検証
+			expect(rankings).toHaveLength(1);
+			expect(rankings[0].commitCount).toBe(2);
+		});
+	});
+
+	it("直近1ヶ月のコミッターランキングを取得できる", async () => {
+		await withTransaction(async () => {
+			// テスト用プロジェクトを作成
+			const project = await projectsRepository.create(
+				buildNewProject({
+					name: "Test Project",
+				}),
+			);
+
+			const now = new Date();
+			const twoMonthsAgo = new Date(now);
+			twoMonthsAgo.setMonth(now.getMonth() - 2);
+			const twoWeeksAgo = new Date(now);
+			twoWeeksAgo.setDate(now.getDate() - 14);
+
+			// 2ヶ月前のコミット（ランキングに含まれない）
+			await commitsRepository.create(
+				buildNewCommit({
+					project_id: project.id,
+					sha: "old-commit",
+					author_name: "Old User",
+					author_email: "old@example.com",
+					authored_date: twoMonthsAgo,
+				}),
+			);
+
+			// 2週間前のコミット（ランキングに含まれる）
+			await commitsRepository.create(
+				buildNewCommit({
+					project_id: project.id,
+					sha: "recent-commit",
+					author_name: "Recent User",
+					author_email: "recent@example.com",
+					authored_date: twoWeeksAgo,
+				}),
+			);
+
+			// 1ヶ月のランキングを取得
+			const rankings = await commitsRepository.getCommitterRanking(
+				project.id,
+				"month",
+			);
+
+			// 検証
+			expect(rankings).toHaveLength(1);
+			expect(rankings[0].authorEmail).toBe("recent@example.com");
+		});
+	});
+
+	it("上位10名までのランキングを返す", async () => {
+		await withTransaction(async () => {
+			// テスト用プロジェクトを作成
+			const project = await projectsRepository.create(
+				buildNewProject({
+					name: "Test Project",
+				}),
+			);
+
+			// 15人の異なるユーザーのコミットを作成
+			for (let i = 0; i < 15; i++) {
+				const commitCount = 15 - i; // 降順でコミット数を設定
+				for (let j = 0; j < commitCount; j++) {
+					await commitsRepository.create(
+						buildNewCommit({
+							project_id: project.id,
+							sha: `user${i}-commit-${j}`,
+							author_name: `User ${i}`,
+							author_email: `user${i}@example.com`,
+							authored_date: new Date(),
+						}),
+					);
+				}
+			}
+
+			// ランキングを取得
+			const rankings = await commitsRepository.getCommitterRanking(
+				project.id,
+				"all",
+				10,
+			);
+
+			// 検証：上位10名のみ
+			expect(rankings).toHaveLength(10);
+			expect(rankings[0].commitCount).toBe(15);
+			expect(rankings[9].commitCount).toBe(6);
+		});
+	});
+
+	it("コミットがない場合は空配列を返す", async () => {
+		await withTransaction(async () => {
+			// テスト用プロジェクトを作成
+			const project = await projectsRepository.create(
+				buildNewProject({
+					name: "Test Project",
+				}),
+			);
+
+			const rankings = await commitsRepository.getCommitterRanking(
+				project.id,
+				"all",
+			);
+			expect(rankings).toEqual([]);
+		});
+	});
+
+	it("異なるプロジェクトのコミットは含まれない", async () => {
+		await withTransaction(async () => {
+			// テスト用プロジェクトを作成
+			const project = await projectsRepository.create(
+				buildNewProject({
+					name: "Test Project",
+				}),
+			);
+
+			// 別のプロジェクトを作成
+			const otherProject = await projectsRepository.create(
+				buildNewProject({
+					name: "Other Project",
+					gitlab_id: 999,
+				}),
+			);
+
+			// 両方のプロジェクトにコミットを作成
+			await commitsRepository.create(
+				buildNewCommit({
+					project_id: project.id,
+					sha: "project1-commit",
+					author_name: "User",
+					author_email: "user@example.com",
+				}),
+			);
+
+			await commitsRepository.create(
+				buildNewCommit({
+					project_id: otherProject.id,
+					sha: "project2-commit",
+					author_name: "User",
+					author_email: "user@example.com",
+				}),
+			);
+
+			// プロジェクト1のランキングを取得
+			const rankings = await commitsRepository.getCommitterRanking(
+				project.id,
+				"all",
+			);
+
+			// 検証：プロジェクト1のコミットのみ
+			expect(rankings).toHaveLength(1);
+			expect(rankings[0].commitCount).toBe(1);
+		});
+	});
+});


### PR DESCRIPTION
## 概要
プロジェクト詳細画面にコミットしたメンバーのランキング機能を追加しました。

## 実装内容
- **期間別ランキング表示**: 全期間、直近1年、直近半年、直近1ヶ月の切り替えが可能
- **上位10名までのランキング**: 順位、作者名、メールアドレス、コミット数を表示
- **メダルアイコン**: 上位3名にはメダル（🥇🥈🥉）を表示
- **効率的なデータ取得**: 期間変更時に必要なデータのみを取得

## 技術詳細
### データベース層
- `CommitsRepository.getCommitterRanking()` メソッドを追加
- PostgreSQLの`GROUP BY`と`COUNT`を使用したSQL集計
- 期間フィルタリング（`authored_date`による絞り込み）
- 既存のインデックス`commits_author_email_idx`を活用

### UI/UXの改善
- 新規`CommitterRankingCard`コンポーネント
- Tailwind CSSとshadcn/uiを使用した統一感のあるデザイン
- レスポンシブ対応
- ローディング状態とエラーハンドリング

### テスト
- リポジトリ層の包括的なユニットテスト（7ケース）
- コンポーネントのインタラクションテスト（9ケース）
- 期間フィルタリング、ランキング順序、上位10名制限などの動作確認

## 変更ファイル
- 🆕 `src/components/commits/committer-ranking-card.tsx`
- 🆕 `src/components/commits/__tests__/committer-ranking-card.test.tsx`
- 🆕 `src/database/repositories/__tests__/committer-ranking.test.ts`
- 🔧 `src/database/repositories/commits.ts`
- 🔧 `src/app/projects/actions.ts`
- 🔧 `src/app/projects/[id]/page.tsx`
- 🔧 `src/app/projects/[id]/__tests__/page.test.tsx`

## テスト結果
- ✅ 全テストケース通過 (223/223)
- ✅ TypeScript型チェック通過
- ✅ Biome lint/format チェック通過

🤖 Generated with [Claude Code](https://claude.ai/code)